### PR TITLE
Mapping and catalog cleanup

### DIFF
--- a/CCM_CISControlsv8_Mapping.xml
+++ b/CCM_CISControlsv8_Mapping.xml
@@ -1,933 +1,787 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This is a mapping example used for development. This file should be moved to the oscal-content repo when this feature is ready. -->
 <mapping-collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 ../OSCAL/mapping.xsd"
- xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="3559d200-4849-41ac-a420-28b2ffa22c52">
-    <metadata>
-        <title>Example mapping between CIS controls and Cloud Controls Matrix v4.0.5</title>
-        <last-modified>2022-04-13T08:37:21.323321800-04:00</last-modified>
-        <version>0.0.1</version>
-        <oscal-version>1.0.3</oscal-version>
-    </metadata>
-    <mapping uuid="9eb2019c-f3be-4f96-947e-58876a46b2a9">
-    	<!-- update UID --> 
-    	<source-resource type="catalog" href="#5ca20d92-aa27-462f-be0d-51385e55149a"/>
-    	<!-- #update UID -->
-    	<target-resource type="catalog" href="#711085f6-c390-4b25-b5f1-30066a56073d"/>
-    	<map uuid="6a9a1161-770e-4556-9740-41e1809e14ea">
-            <relationship>equivalent-to</relationship>
-            <source type="control" id-ref="#cis-1.1"/>
-            <target type="control" id-ref="#UEM-04">
-                <!-- TODO: consider a way to reference parameters allowing the review period of at least bi-annually to be described -->
-                <!-- <using-param id="cm-08_odp.02">at least bi-annually</using-param>-->
-            </target>
-            <target type="control" id-ref="#cm-8.1"/>
-            <remarks>
-                <p>The combination of SP 800-53 CM-8 and CM-8(1) describe similar implementation requirements to CIS 1.1.</p>
-            </remarks>
-        </map>
+	xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 ../OSCAL/mapping.xsd"
+	xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="3559d200-4849-41ac-a420-28b2ffa22c52">
+	<metadata>
+		<title>Example mapping between CIS controls and Cloud Controls Matrix v4.0.5</title>
+		<last-modified>2022-04-13T08:37:21.323321800-04:00</last-modified>
+		<version>0.0.1</version>
+		<oscal-version>1.0.3</oscal-version>
+	</metadata>
+	<mapping uuid="9eb2019c-f3be-4f96-947e-58876a46b2a9">
+		<!-- update UID -->
+		<source-resource type="catalog" href="#5ca20d92-aa27-462f-be0d-51385e55149a"/>
+		<!-- #update UID -->
+		<target-resource type="catalog" href="#711085f6-c390-4b25-b5f1-30066a56073d"/>
+		<map uuid="6a9a1161-770e-4556-9740-41e1809e14ea">
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-1.1"/>
+			<target type="control" id-ref="#UEM-04">
+				<!-- TODO: consider a way to reference parameters allowing the review period of at least bi-annually to be described -->
+				<!-- <using-param id="cm-08_odp.02">at least bi-annually</using-param>-->
+			</target>
+			<target type="control" id-ref="#cm-8.1"/>
+			<remarks>
+				<p>The combination of SP 800-53 CM-8 and CM-8(1) describe similar implementation
+					requirements to CIS 1.1.</p>
+			</remarks>
+		</map>
 		<map uuid="383ee0c0-8739-4e61-b33e-f6f92b0bc7ed">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-1.1"/>
-		<target type="control" id-ref="#UEM-04">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-1.1"/>
+			<target type="control" id-ref="#UEM-04"> </target>
 		</map>
 		<map uuid="23e6fbec-3e36-42d1-aff5-98f28145ae32">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-1.3"/>
-		<target type="control" id-ref="#UEM-05">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-1.3"/>
+			<target type="control" id-ref="#UEM-05"> </target>
 		</map>
 		<map uuid="2162f11d-f51d-4164-80fc-2c80241d8c35">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-2.1"/>
-		<target type="control" id-ref="#UEM-02">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-2.1"/>
+			<target type="control" id-ref="#UEM-02"> </target>
 		</map>
 		<map uuid="a350cef1-140f-4576-92a9-7a79db43bf2b">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.1"/>
-		<target type="control" id-ref="#DSP-01">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.1"/>
+			<target type="control" id-ref="#DSP-01"> </target>
 		</map>
 		<map uuid="14f99cad-40b8-4087-b690-9a820289f148">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-3.1"/>
-		<target type="control" id-ref="#DSP-06">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-3.1"/>
+			<target type="control" id-ref="#DSP-06"> </target>
 		</map>
 		<map uuid="78f99280-2336-4d24-a864-5df5663ac715">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-3.1"/>
-		<target type="control" id-ref="#GRC-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-3.1"/>
+			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="f8592824-6d34-41dd-8b3a-0b3cc9a52954">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-3.2"/>
-		<target type="control" id-ref="#DSP-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-3.2"/>
+			<target type="control" id-ref="#DSP-03"> </target>
 		</map>
 		<map uuid="12955adb-d3ab-4a05-b5f1-086a1ba543bb">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.3"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.3"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="2ed2eaf9-f53c-45ee-aa9d-930454686307">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.3"/>
-		<target type="control" id-ref="#IAM-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.3"/>
+			<target type="control" id-ref="#IAM-05"> </target>
 		</map>
 		<map uuid="02f2174f-0acb-450e-8313-722fea41f381">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.4"/>
-		<target type="control" id-ref="#DSP-16">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.4"/>
+			<target type="control" id-ref="#DSP-16"> </target>
 		</map>
 		<map uuid="0f90beb8-8bfc-4380-ab52-f9d163ccaa1c">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.5"/>
-		<target type="control" id-ref="#DSP-02">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.5"/>
+			<target type="control" id-ref="#DSP-02"> </target>
 		</map>
 		<map uuid="c0be2e0b-aeff-4fd1-9dd6-fe57d1fdb2b1">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.5"/>
-		<target type="control" id-ref="#DSP-16">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.5"/>
+			<target type="control" id-ref="#DSP-16"> </target>
 		</map>
 		<map uuid="91dd6667-6784-4233-98c2-0c1810ead394">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.6"/>
-		<target type="control" id-ref="#CEK-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.6"/>
+			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="222f3372-32b5-4970-82d8-e4a9bdd3075c">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.6"/>
-		<target type="control" id-ref="#UEM-08">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.6"/>
+			<target type="control" id-ref="#UEM-08"> </target>
 		</map>
 		<map uuid="824f98e6-913f-4f61-be23-f0cfcd6620b6">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.7"/>
-		<target type="control" id-ref="#DSP-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.7"/>
+			<target type="control" id-ref="#DSP-01"> </target>
 		</map>
 		<map uuid="2d57f872-16b0-4dd3-88db-e181fc79dae0">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.7"/>
-		<target type="control" id-ref="#DSP-04">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.7"/>
+			<target type="control" id-ref="#DSP-04"> </target>
 		</map>
 		<map uuid="b049ec72-f315-4abf-a043-a049927847d0">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.8"/>
-		<target type="control" id-ref="#DSP-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.8"/>
+			<target type="control" id-ref="#DSP-05"> </target>
 		</map>
 		<map uuid="ec7db17a-fbbd-41b0-b106-5014f2d2ebf4">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.8"/>
-		<target type="control" id-ref="#IVS-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.8"/>
+			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="95ede245-123a-4f42-8c00-97793f90d731">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.10"/>
-		<target type="control" id-ref="#CEK-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.10"/>
+			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="95b082bc-4301-481d-82fa-2787c169e831">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.10"/>
-		<target type="control" id-ref="#DSP-10">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.10"/>
+			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="9ed3888d-1816-4876-acc8-cfa29571dedb">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.10"/>
-		<target type="control" id-ref="#DSP-10">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.10"/>
+			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="a9e5e849-f3fa-4778-80b0-b564e78167bb">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.10"/>
-		<target type="control" id-ref="#IVS-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.10"/>
+			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="e2a6e1e3-2e1d-4bbd-9c86-461f0bb495e9">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.11"/>
-		<target type="control" id-ref="#CEK-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.11"/>
+			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="88fa58c5-f271-4ad7-8475-54f3469f1312">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.12"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.12"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="042cf8c5-0605-4959-89bc-6d2cf73730aa">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-3.13"/>
-		<target type="control" id-ref="#DSP-10">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-3.13"/>
+			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="a0205cf3-f7ab-494d-ba6b-cfdcd123f348">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-3.13"/>
-		<target type="control" id-ref="#UEM-11">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-3.13"/>
+			<target type="control" id-ref="#UEM-11"> </target>
 		</map>
 		<map uuid="46d9b21a-c28f-49f9-ad63-ac82cf6f9070">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.14"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.14"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="8c5c5704-d97f-42d0-8791-0d976e45454f">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-3.14"/>
-		<target type="control" id-ref="#IAM-12">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-3.14"/>
+			<target type="control" id-ref="#IAM-12"> </target>
 		</map>
 		<map uuid="cc18b09d-137f-4681-91af-4dd5901eda2a">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-3.14"/>
-		<target type="control" id-ref="#LOG-04">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-3.14"/>
+			<target type="control" id-ref="#LOG-04"> </target>
 		</map>
 		<map uuid="ca35c1e0-4afd-48a0-b908-176dab5fcf83">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-4.1"/>
-		<target type="control" id-ref="#CCC-01">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-4.1"/>
+			<target type="control" id-ref="#CCC-01"> </target>
 		</map>
 		<map uuid="b3611321-9627-43f3-8fe9-5b521105beb2">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-4.1"/>
-		<target type="control" id-ref="#CCC-01">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-4.1"/>
+			<target type="control" id-ref="#CCC-01"> </target>
 		</map>
 		<map uuid="529b0131-1b9c-480e-9910-e4ea925a0052">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-4.1"/>
-		<target type="control" id-ref="#GRC-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-4.1"/>
+			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="259e07b8-e640-424e-a2be-83c4abd652b7">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-4.1"/>
-		<target type="control" id-ref="#IVS-04">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-4.1"/>
+			<target type="control" id-ref="#IVS-04"> </target>
 		</map>
 		<map uuid="2ac91f70-c2c9-42ad-b969-0d8031835610">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-4.2"/>
-		<target type="control" id-ref="#IVS-04">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-4.2"/>
+			<target type="control" id-ref="#IVS-04"> </target>
 		</map>
 		<map uuid="8328a6ed-4dfd-4577-875c-6d2baf9d1970">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-4.3"/>
-		<target type="control" id-ref="#UEM-06">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-4.3"/>
+			<target type="control" id-ref="#UEM-06"> </target>
 		</map>
 		<map uuid="f23c64ca-30ef-4801-b3a4-e66077d7e1a0">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-4.5"/>
-		<target type="control" id-ref="#UEM-10">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-4.5"/>
+			<target type="control" id-ref="#UEM-10"> </target>
 		</map>
 		<map uuid="9ac4010d-b0ac-453d-8170-1a29f4f78e6d">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-4.11"/>
-		<target type="control" id-ref="#UEM-13">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-4.11"/>
+			<target type="control" id-ref="#UEM-13"> </target>
 		</map>
 		<map uuid="b4b9df39-e015-453f-a877-5052675adf60">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-4.12"/>
-		<target type="control" id-ref="#HRS-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-4.12"/>
+			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="a2af0058-8daa-4e5c-9a02-90297dcd284c">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-5.1"/>
-		<target type="control" id-ref="#IAM-03">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-5.1"/>
+			<target type="control" id-ref="#IAM-03"> </target>
 		</map>
 		<map uuid="df8c35c6-f421-4b05-ae33-c63ac392a756">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-5.1"/>
-		<target type="control" id-ref="#IAM-08">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-5.1"/>
+			<target type="control" id-ref="#IAM-08"> </target>
 		</map>
 		<map uuid="e690fa8d-a7c2-4475-86a5-89a5fc0a2d37">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-5.1"/>
-		<target type="control" id-ref="#IAM-10">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-5.1"/>
+			<target type="control" id-ref="#IAM-10"> </target>
 		</map>
 		<map uuid="25f18273-feb1-40d7-9921-7427eb596306">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-5.1"/>
-		<target type="control" id-ref="#IAM-16">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-5.1"/>
+			<target type="control" id-ref="#IAM-16"> </target>
 		</map>
 		<map uuid="ddc4998c-89fd-4164-8726-55a944ff3863">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-5.2"/>
-		<target type="control" id-ref="#IAM-02">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-5.2"/>
+			<target type="control" id-ref="#IAM-02"> </target>
 		</map>
 		<map uuid="0925eb00-e45a-42c7-87eb-fee3aa36a234">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-5.4"/>
-		<target type="control" id-ref="#IAM-09">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-5.4"/>
+			<target type="control" id-ref="#IAM-09"> </target>
 		</map>
 		<map uuid="abbf00fc-a5ac-43dd-91c7-d305edc52258">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-5.5"/>
-		<target type="control" id-ref="#IAM-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-5.5"/>
+			<target type="control" id-ref="#IAM-03"> </target>
 		</map>
 		<map uuid="41f53f60-f768-42ff-8d15-a7ea92e20450">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.1"/>
-		<target type="control" id-ref="#IAM-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.1"/>
+			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="c0fa155e-9c82-4150-a601-ccf68afa1328">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.1"/>
-		<target type="control" id-ref="#IAM-06">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.1"/>
+			<target type="control" id-ref="#IAM-06"> </target>
 		</map>
 		<map uuid="0127c0ad-c57c-4fa7-aa40-322ece347c8f">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.1"/>
-		<target type="control" id-ref="#IAM-07">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.1"/>
+			<target type="control" id-ref="#IAM-07"> </target>
 		</map>
 		<map uuid="27b7b4cd-4215-4caa-8fd1-69cfed7bf265">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.2"/>
-		<target type="control" id-ref="#HRS-06">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.2"/>
+			<target type="control" id-ref="#HRS-06"> </target>
 		</map>
 		<map uuid="96954b3a-2f03-4ce8-adcf-6b7d92610140">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.2"/>
-		<target type="control" id-ref="#IAM-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.2"/>
+			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="137a4718-3975-4ce2-bab6-7bd0dd8d7b7a">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-6.2"/>
-		<target type="control" id-ref="#IAM-07">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-6.2"/>
+			<target type="control" id-ref="#IAM-07"> </target>
 		</map>
 		<map uuid="31bd8a68-1791-4d9f-99ab-e11de563489e">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.4"/>
-		<target type="control" id-ref="#HRS-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.4"/>
+			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="b5b5068b-2bb9-48f3-805c-c61c54bcbf3f">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.5"/>
-		<target type="control" id-ref="#IAM-10">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.5"/>
+			<target type="control" id-ref="#IAM-10"> </target>
 		</map>
 		<map uuid="365c9f4f-d112-4a6e-8d18-a62189d5651b">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.5"/>
-		<target type="control" id-ref="#IAM-14">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.5"/>
+			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="a38dee63-c5c0-4d57-9756-f0d3ddd3f6d6">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-6.6"/>
-		<target type="control" id-ref="#IAM-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-6.6"/>
+			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="c0baccf0-a438-4d9e-9e81-d4501971d582">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-6.8"/>
-		<target type="control" id-ref="#IAM-04">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-6.8"/>
+			<target type="control" id-ref="#IAM-04"> </target>
 		</map>
 		<map uuid="4b90b83e-ca8f-4d94-957c-6c0212e763e6">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-6.8"/>
-		<target type="control" id-ref="#IAM-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-6.8"/>
+			<target type="control" id-ref="#IAM-05"> </target>
 		</map>
 		<map uuid="4f324b27-3b58-49a4-a25d-779685b1023d">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-6.8"/>
-		<target type="control" id-ref="#IAM-16">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-6.8"/>
+			<target type="control" id-ref="#IAM-16"> </target>
 		</map>
 		<map uuid="3f109fc9-68f5-4f70-9290-42ed674d59ce">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-7.1"/>
-		<target type="control" id-ref="#TVM-01">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-7.1"/>
+			<target type="control" id-ref="#TVM-01"> </target>
 		</map>
 		<map uuid="6f13ff2a-7e64-492e-99ee-aabbe79b37e1">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-7.1"/>
-		<target type="control" id-ref="#TVM-07">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-7.1"/>
+			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="af47907d-4def-4a92-adf8-b97f588d37b9">
-		<relationship>supserset</relationship>
-		<source type="control" id-ref="#cis-7.1"/>
-		<target type="control" id-ref="#TVM-09">
-		</target>
+			<relationship>supserset</relationship>
+			<source type="control" id-ref="#cis-7.1"/>
+			<target type="control" id-ref="#TVM-09"> </target>
 		</map>
 		<map uuid="5352bb00-3207-455e-9972-7c0ed30db637">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-7.2"/>
-		<target type="control" id-ref="#A&amp;Amp;A-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-7.2"/>
+			<target type="control" id-ref="#A&amp;Amp;A-03"> </target>
 		</map>
 		<map uuid="44725d67-6f5a-4ab4-8ea2-eca43418f077">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-7.2"/>
-		<target type="control" id-ref="#TVM-08">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-7.2"/>
+			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
 		<map uuid="d4add505-1cd1-441c-b28b-f6afcdc96d3c">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-7.2"/>
-		<target type="control" id-ref="#TVM-10">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-7.2"/>
+			<target type="control" id-ref="#TVM-10"> </target>
 		</map>
 		<map uuid="06c281c0-eb00-44a3-8b62-ad36c2644e27">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-7.3"/>
-		<target type="control" id-ref="#UEM-07">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-7.3"/>
+			<target type="control" id-ref="#UEM-07"> </target>
 		</map>
 		<map uuid="dbf050b6-cb7f-4d8b-8989-d4dbcd4efe34">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-7.4"/>
-		<target type="control" id-ref="#UEM-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-7.4"/>
+			<target type="control" id-ref="#UEM-03"> </target>
 		</map>
 		<map uuid="c178e1f7-5581-437d-8505-082495c16f74">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-7.5"/>
-		<target type="control" id-ref="#TVM-07">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-7.5"/>
+			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="295ef882-ba37-4889-9a49-f43e7141d115">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-7.6"/>
-		<target type="control" id-ref="#TVM-07">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-7.6"/>
+			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="1c8344e7-3819-4d3f-a587-aea14c1db0e1">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-7.7"/>
-		<target type="control" id-ref="#TVM-03">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-7.7"/>
+			<target type="control" id-ref="#TVM-03"> </target>
 		</map>
 		<map uuid="de1c4e0f-f6a0-4302-b161-1e5bdfd34e04">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-8.1"/>
-		<target type="control" id-ref="#A&amp;A-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-8.1"/>
+			<target type="control" id-ref="#A&amp;A-01"> </target>
 		</map>
 		<map uuid="56b70c69-e466-4b79-9ad9-971d401f1bc3">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-8.1"/>
-		<target type="control" id-ref="#LOG-01">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-8.1"/>
+			<target type="control" id-ref="#LOG-01"> </target>
 		</map>
 		<map uuid="d9b2134c-f84e-459a-9f97-71d224f13462">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-8.1"/>
-		<target type="control" id-ref="#LOG-07">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-8.1"/>
+			<target type="control" id-ref="#LOG-07"> </target>
 		</map>
 		<map uuid="84db0645-9b8d-4efe-893d-ffe2cb3867c8">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-8.2"/>
-		<target type="control" id-ref="#LOG-08">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-8.2"/>
+			<target type="control" id-ref="#LOG-08"> </target>
 		</map>
 		<map uuid="e91647e9-de63-419e-8b69-8021d073c49c">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-8.4"/>
-		<target type="control" id-ref="#LOG-06">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-8.4"/>
+			<target type="control" id-ref="#LOG-06"> </target>
 		</map>
 		<map uuid="24672f5a-38f5-49b2-9427-d6205a703a95">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-8.5"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-8.5"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="cb7bdf51-7d8d-4575-9080-3d74266a4956">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-8.5"/>
-		<target type="control" id-ref="#LOG-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-8.5"/>
+			<target type="control" id-ref="#LOG-03"> </target>
 		</map>
 		<map uuid="cd0d9304-d263-4b15-a940-e29ce11a5952">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-8.10"/>
-		<target type="control" id-ref="#LOG-02">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-8.10"/>
+			<target type="control" id-ref="#LOG-02"> </target>
 		</map>
 		<map uuid="cb23c6be-2b68-422f-b96a-4649ac767cb7">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-8.11"/>
-		<target type="control" id-ref="#LOG-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-8.11"/>
+			<target type="control" id-ref="#LOG-05"> </target>
 		</map>
 		<map uuid="637f084d-07f0-4f1c-aefb-352dc60127ad">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-8.11"/>
-		<target type="control" id-ref="#LOG-13">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-8.11"/>
+			<target type="control" id-ref="#LOG-13"> </target>
 		</map>
 		<map uuid="ce24c911-24de-4db6-b513-c5b56e43e9e8">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-9.7"/>
-		<target type="control" id-ref="#TVM-02">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-9.7"/>
+			<target type="control" id-ref="#TVM-02"> </target>
 		</map>
 		<map uuid="071a7f32-b337-4907-8971-057b6d51dd85">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-10.1"/>
-		<target type="control" id-ref="#TVM-02">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-10.1"/>
+			<target type="control" id-ref="#TVM-02"> </target>
 		</map>
 		<map uuid="e7507be2-11d7-4e3c-8c7b-506026eb38ef">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-10.1"/>
-		<target type="control" id-ref="#UEM-09">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-10.1"/>
+			<target type="control" id-ref="#UEM-09"> </target>
 		</map>
 		<map uuid="429dec9a-09e9-48d7-a1b9-6e28f88b8a76">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-10.2"/>
-		<target type="control" id-ref="#TVM-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-10.2"/>
+			<target type="control" id-ref="#TVM-04"> </target>
 		</map>
 		<map uuid="08f4e56c-fe2d-447f-aa5b-287b1554079d">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-12.2"/>
-		<target type="control" id-ref="#DSP-07">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-12.2"/>
+			<target type="control" id-ref="#DSP-07"> </target>
 		</map>
 		<map uuid="58d38197-854b-4906-99f9-6a6dace91752">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-12.2"/>
-		<target type="control" id-ref="#IVS-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-12.2"/>
+			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="957b9cd4-47c5-4f0b-b92e-7e8d1cf7c253">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-12.4"/>
-		<target type="control" id-ref="#IVS-08">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-12.4"/>
+			<target type="control" id-ref="#IVS-08"> </target>
 		</map>
 		<map uuid="b2f139c5-382e-4838-ad66-8e2605cbf2b9">
-		<relationship>intersects</relationship>
-		<source type="control" id-ref="#cis-12.5"/>
-		<target type="control" id-ref="#IAM-14">
-		</target>
+			<relationship>intersects</relationship>
+			<source type="control" id-ref="#cis-12.5"/>
+			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="5a5149e7-f522-4871-88a5-5134aeb64d6f">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-12.7"/>
-		<target type="control" id-ref="#HRS-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-12.7"/>
+			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="5bddbe2f-cd2e-4133-a3c9-b6602876a14a">
-		<relationship>intersects</relationship>
-		<source type="control" id-ref="#cis-12.7"/>
-		<target type="control" id-ref="#IAM-14">
-		</target>
+			<relationship>intersects</relationship>
+			<source type="control" id-ref="#cis-12.7"/>
+			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="e4dc90c5-f6e8-4262-9f81-e91f77f85628">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-13.1"/>
-		<target type="control" id-ref="#LOG-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-13.1"/>
+			<target type="control" id-ref="#LOG-03"> </target>
 		</map>
 		<map uuid="8a792030-f33b-4ae6-86a4-5887a8da25ea">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.1"/>
-		<target type="control" id-ref="#SEF-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.1"/>
+			<target type="control" id-ref="#SEF-01"> </target>
 		</map>
 		<map uuid="8898cb4d-bd5a-4579-976f-469801b77e44">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.3"/>
-		<target type="control" id-ref="#IVS-09">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.3"/>
+			<target type="control" id-ref="#IVS-09"> </target>
 		</map>
 		<map uuid="9e50aa9e-ef48-4125-94b7-f8a5af255e5c">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.5"/>
-		<target type="control" id-ref="#HRS-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.5"/>
+			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="e46c826a-47ca-409d-aeea-67c857d48282">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.6"/>
-		<target type="control" id-ref="#IVS-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.6"/>
+			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="7c7708cb-6fd7-4e04-a897-5095745768f7">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.8"/>
-		<target type="control" id-ref="#IVS-09">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.8"/>
+			<target type="control" id-ref="#IVS-09"> </target>
 		</map>
 		<map uuid="0d77eccd-3df7-4c41-9299-25b58a73491c">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-13.9"/>
-		<target type="control" id-ref="#IVS-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-13.9"/>
+			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="b6bfa101-06bf-4169-8711-114d67f93cbf">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-14.1"/>
-		<target type="control" id-ref="#GRC-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-14.1"/>
+			<target type="control" id-ref="#GRC-05"> </target>
 		</map>
 		<map uuid="8bbac20f-5444-4664-ade0-2150798f1327">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-14.1"/>
-		<target type="control" id-ref="#HRS-11">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-14.1"/>
+			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="4e546bea-9675-4c6a-8ce0-94d11fb0a4bb">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-14.1"/>
-		<target type="control" id-ref="#GRC-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-14.1"/>
+			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="531ace4b-35c3-4d8c-b805-c224ada6a83d">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.2"/>
-		<target type="control" id-ref="#HRS-11">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.2"/>
+			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="a0074c66-480c-4cb7-badc-0c9fd5f785a2">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.3"/>
-		<target type="control" id-ref="#GRC-05">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.3"/>
+			<target type="control" id-ref="#GRC-05"> </target>
 		</map>
 		<map uuid="29652793-13aa-4b30-a9d9-585279a0c115">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.3"/>
-		<target type="control" id-ref="#HRS-11">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.3"/>
+			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="e8a8e264-1044-4e76-97c8-42688bccba09">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.4"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.4"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="57b39cd8-2494-4336-88af-ca19b8f1d5e8">
-		<relationship>intersects</relationship>
-		<source type="control" id-ref="#cis-14.4"/>
-		<target type="control" id-ref="#GRC-01">
-		</target>
+			<relationship>intersects</relationship>
+			<source type="control" id-ref="#cis-14.4"/>
+			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="90f58a67-9e97-4c54-add0-21ece8adc949">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-14.4"/>
-		<target type="control" id-ref="#HRS-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-14.4"/>
+			<target type="control" id-ref="#HRS-03"> </target>
 		</map>
 		<map uuid="7ac6b858-3106-495d-8bf4-23902dcfcf71">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-14.4"/>
-		<target type="control" id-ref="#HRS-12">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-14.4"/>
+			<target type="control" id-ref="#HRS-12"> </target>
 		</map>
 		<map uuid="42cc1ba2-362d-43cc-b441-7bbad551a673">
-		<relationship>intersects</relationship>
-		<source type="control" id-ref="#cis-14.5"/>
-		<target type="control" id-ref="#GRC-01">
-		</target>
+			<relationship>intersects</relationship>
+			<source type="control" id-ref="#cis-14.5"/>
+			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="a6f9056c-ce90-4145-bd86-143ea34e3671">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.5"/>
-		<target type="control" id-ref="#HRS-11">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.5"/>
+			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="c0c778df-a55d-48b1-b1a0-5ec7b4dfb90f">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.6"/>
-		<target type="control" id-ref="#HRS-11">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.6"/>
+			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="ff0525a2-b9c5-4a2e-a2ac-bacd99a8aa67">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.7"/>
-		<target type="control" id-ref="#DSP-17">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.7"/>
+			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="7cdb93c4-e295-476c-8850-b46941b6ea74">
-		<relationship>intersects</relationship>
-		<source type="control" id-ref="#cis-14.8"/>
-		<target type="control" id-ref="#GRC-01">
-		</target>
+			<relationship>intersects</relationship>
+			<source type="control" id-ref="#cis-14.8"/>
+			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="1a7b7c1e-b876-41a9-8479-1bf50ceae9f9">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.8"/>
-		<target type="control" id-ref="#HRS-04">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.8"/>
+			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="fa93b58d-400e-43d3-bf26-ff57d5a75de2">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-14.9"/>
-		<target type="control" id-ref="#HRS-09">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-14.9"/>
+			<target type="control" id-ref="#HRS-09"> </target>
 		</map>
 		<map uuid="832316fd-c936-4149-b52a-29cd12e180c5">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-14.9"/>
-		<target type="control" id-ref="#HRS-12">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-14.9"/>
+			<target type="control" id-ref="#HRS-12"> </target>
 		</map>
 		<map uuid="f0aa30e3-c629-4bed-b1d0-379a45217d7b">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-15.1"/>
-		<target type="control" id-ref="#STA-07">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-15.1"/>
+			<target type="control" id-ref="#STA-07"> </target>
 		</map>
 		<map uuid="24c77842-ad8b-484b-9eba-64be619a8b51">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-15.3"/>
-		<target type="control" id-ref="#GRC-02">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-15.3"/>
+			<target type="control" id-ref="#GRC-02"> </target>
 		</map>
 		<map uuid="d6a4b5b7-bda3-47dd-9eb9-f3b8cc2b3050">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-15.3"/>
-		<target type="control" id-ref="#STA-08">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-15.3"/>
+			<target type="control" id-ref="#STA-08"> </target>
 		</map>
 		<map uuid="0d2ce502-9913-492c-9dbc-0b84e2a86694">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-15.4"/>
-		<target type="control" id-ref="#STA-09">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-15.4"/>
+			<target type="control" id-ref="#STA-09"> </target>
 		</map>
 		<map uuid="a31ec15b-5b56-4c01-a658-6626655ebb69">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-15.4"/>
-		<target type="control" id-ref="#STA-10">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-15.4"/>
+			<target type="control" id-ref="#STA-10"> </target>
 		</map>
 		<map uuid="0998c607-88bf-4d55-bbe8-9707b6e0d0ae">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-15.4"/>
-		<target type="control" id-ref="#UEM-14">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-15.4"/>
+			<target type="control" id-ref="#UEM-14"> </target>
 		</map>
 		<map uuid="40d9de65-15b4-42dc-8db6-3360e76dee22">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-15.5"/>
-		<target type="control" id-ref="#STA-12">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-15.5"/>
+			<target type="control" id-ref="#STA-12"> </target>
 		</map>
 		<map uuid="9152d107-c4cb-4cf4-87f3-d1a15decc73a">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-15.5"/>
-		<target type="control" id-ref="#STA-13">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-15.5"/>
+			<target type="control" id-ref="#STA-13"> </target>
 		</map>
 		<map uuid="d36fe370-5d14-4983-8123-109eeac3b29d">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-15.6"/>
-		<target type="control" id-ref="#STA-14">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-15.6"/>
+			<target type="control" id-ref="#STA-14"> </target>
 		</map>
 		<map uuid="b64583a0-da87-4636-a8b8-6d2b7d7ac319">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-16.1"/>
-		<target type="control" id-ref="#AIS-01">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-16.1"/>
+			<target type="control" id-ref="#AIS-01"> </target>
 		</map>
 		<map uuid="f45bd4a4-1740-402c-bfdb-ec84f88df42f">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-16.1"/>
-		<target type="control" id-ref="#AIS-04">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-16.1"/>
+			<target type="control" id-ref="#AIS-04"> </target>
 		</map>
 		<map uuid="b0f3dc8f-2a62-4f2f-97f7-f58d64fe23ea">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-16.2"/>
-		<target type="control" id-ref="#AIS-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-16.2"/>
+			<target type="control" id-ref="#AIS-03"> </target>
 		</map>
 		<map uuid="067f2fc0-1df3-4cb4-9bc4-2387f720aef4">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-16.2"/>
-		<target type="control" id-ref="#AIS-07">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-16.2"/>
+			<target type="control" id-ref="#AIS-07"> </target>
 		</map>
 		<map uuid="ef8add2b-e0f2-4ba4-85fa-0f8c9d1c1c29">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-16.4"/>
-		<target type="control" id-ref="#GRC-02">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-16.4"/>
+			<target type="control" id-ref="#GRC-02"> </target>
 		</map>
 		<map uuid="fe022e31-b394-479a-9f03-a21261a0493d">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-16.6"/>
-		<target type="control" id-ref="#AIS-07">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-16.6"/>
+			<target type="control" id-ref="#AIS-07"> </target>
 		</map>
 		<map uuid="cb2e3386-c8f0-4d70-aaec-3052ebe358f1">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-16.6"/>
-		<target type="control" id-ref="#TVM-08">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-16.6"/>
+			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
 		<map uuid="bda3184b-060b-4764-b9a1-0bb8e59fcca8">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-16.7"/>
-		<target type="control" id-ref="#AIS-02">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-16.7"/>
+			<target type="control" id-ref="#AIS-02"> </target>
 		</map>
 		<map uuid="c0cde3e1-aef6-4d77-a02a-8cc983d7e5ec">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-16.8"/>
-		<target type="control" id-ref="#IVS-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-16.8"/>
+			<target type="control" id-ref="#IVS-05"> </target>
 		</map>
 		<map uuid="71f1432c-18ad-4f85-a750-53d4e4a9dc12">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-16.10"/>
-		<target type="control" id-ref="#DSP-07">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-16.10"/>
+			<target type="control" id-ref="#DSP-07"> </target>
 		</map>
 		<map uuid="9bf8c233-d453-4013-9493-13b706c73da9">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-16.12"/>
-		<target type="control" id-ref="#AIS-05">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-16.12"/>
+			<target type="control" id-ref="#AIS-05"> </target>
 		</map>
 		<map uuid="bd9f9079-083e-47bc-b2ec-a8824737c489">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-16.13"/>
-		<target type="control" id-ref="#AIS-05">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-16.13"/>
+			<target type="control" id-ref="#AIS-05"> </target>
 		</map>
 		<map uuid="1c7e970c-3807-4a29-aa72-74e1b1b6358a">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-17.1"/>
-		<target type="control" id-ref="#BCR-01">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-17.1"/>
+			<target type="control" id-ref="#BCR-01"> </target>
 		</map>
 		<map uuid="71c0bf75-0466-458b-a842-68af5f3cdf1b">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-17.1"/>
-		<target type="control" id-ref="#SEF-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-17.1"/>
+			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="0fe69621-ddcd-4f54-95f2-5a3a329eec9e">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-17.2"/>
-		<target type="control" id-ref="#SEF-08">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-17.2"/>
+			<target type="control" id-ref="#SEF-08"> </target>
 		</map>
 		<map uuid="5a13e251-3a33-4c27-a26a-9d0b9917f60e">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-17.2"/>
-		<target type="control" id-ref="#SEF-07">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-17.2"/>
+			<target type="control" id-ref="#SEF-07"> </target>
 		</map>
 		<map uuid="5600b5b0-a870-4ad9-a673-eef11c51deca">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-17.4"/>
-		<target type="control" id-ref="#SEF-01">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-17.4"/>
+			<target type="control" id-ref="#SEF-01"> </target>
 		</map>
 		<map uuid="6807754f-2032-4ad5-8a85-b9d63c26402f">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-17.4"/>
-		<target type="control" id-ref="#SEF-02">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-17.4"/>
+			<target type="control" id-ref="#SEF-02"> </target>
 		</map>
 		<map uuid="c89042bb-922d-42b9-be2c-17588e60be9a">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-17.4"/>
-		<target type="control" id-ref="#SEF-03">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-17.4"/>
+			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="4d084a7c-e27a-4e8d-a00b-f5afeb9f5d9e">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-17.4"/>
-		<target type="control" id-ref="#SEF-06">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-17.4"/>
+			<target type="control" id-ref="#SEF-06"> </target>
 		</map>
 		<map uuid="1cb4a029-07ee-4817-ab32-289db9c7ba2e">
-		<relationship>superset-of</relationship>
-		<source type="control" id-ref="#cis-17.4"/>
-		<target type="control" id-ref="#GRC-03">
-		</target>
+			<relationship>superset-of</relationship>
+			<source type="control" id-ref="#cis-17.4"/>
+			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="0c54052b-fe01-44aa-aef5-a30fe489e838">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-17.5"/>
-		<target type="control" id-ref="#SEF-03">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-17.5"/>
+			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="cb8d447b-c97a-45a3-8cd4-a61f4466a35d">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-17.7"/>
-		<target type="control" id-ref="#SEF-04">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-17.7"/>
+			<target type="control" id-ref="#SEF-04"> </target>
 		</map>
 		<map uuid="a1713855-8283-4f2d-87e8-cf77de583483">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-17.9"/>
-		<target type="control" id-ref="#SEF-05">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-17.9"/>
+			<target type="control" id-ref="#SEF-05"> </target>
 		</map>
 		<map uuid="838991d0-b2f2-4c9e-b370-01ff63c85061">
-		<relationship>equivalent-to</relationship>
-		<source type="control" id-ref="#cis-18.1"/>
-		<target type="control" id-ref="#TVM-06">
-		</target>
+			<relationship>equivalent-to</relationship>
+			<source type="control" id-ref="#cis-18.1"/>
+			<target type="control" id-ref="#TVM-06"> </target>
 		</map>
 		<map uuid="19299403-6122-4d97-b5f1-907137699c6b">
-		<relationship>subset-of</relationship>
-		<source type="control" id-ref="#cis-18.3"/>
-		<target type="control" id-ref="#TVM-08">
-		</target>
+			<relationship>subset-of</relationship>
+			<source type="control" id-ref="#cis-18.3"/>
+			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
-    </mapping>
-    <back-matter>
-        <resource uuid="a84961de-55ae-4bf3-a2d3-86cc32b651af">
-        	<rlink href="cis-controls-v8_OSCAL-1.0.xml" media-type="application/oscal+xml"/>
-        </resource>
-        <resource uuid="711085f6-c390-4b25-b5f1-30066a56073d">
-        	<!-- TODO: this rlink needs to point to the CCM. -->
-            <rlink href="https://github.com/usnistgov/oscal-content/raw/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml" media-type="application/oscal+xml"/>
-        </resource>
-    </back-matter>
-</mapping-collection> 
+	</mapping>
+	<back-matter>
+		<resource uuid="a84961de-55ae-4bf3-a2d3-86cc32b651af">
+			<rlink href="cis-controls-v8_OSCAL-1.0.xml" media-type="application/oscal+xml"/>
+		</resource>
+		<resource uuid="711085f6-c390-4b25-b5f1-30066a56073d">
+			<!-- TODO: this rlink needs to point to the CCM. -->
+			<rlink
+				href="https://github.com/usnistgov/oscal-content/raw/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"
+				media-type="application/oscal+xml"/>
+		</resource>
+	</back-matter>
+</mapping-collection>

--- a/CCM_CISControlsv8_Mapping.xml
+++ b/CCM_CISControlsv8_Mapping.xml
@@ -30,747 +30,747 @@
 		<map uuid="383ee0c0-8739-4e61-b33e-f6f92b0bc7ed">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-1.1"/>
-			<target type="control" id-ref="#UEM-04"> </target>
+			<target type="control" id-ref="#UEM-04"/>
 		</map>
 		<map uuid="23e6fbec-3e36-42d1-aff5-98f28145ae32">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-1.3"/>
-			<target type="control" id-ref="#UEM-05"> </target>
+			<target type="control" id-ref="#UEM-05"/>
 		</map>
 		<map uuid="2162f11d-f51d-4164-80fc-2c80241d8c35">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-2.1"/>
-			<target type="control" id-ref="#UEM-02"> </target>
+			<target type="control" id-ref="#UEM-02"/>
 		</map>
 		<map uuid="a350cef1-140f-4576-92a9-7a79db43bf2b">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.1"/>
-			<target type="control" id-ref="#DSP-01"> </target>
+			<target type="control" id-ref="#DSP-01"/>
 		</map>
 		<map uuid="14f99cad-40b8-4087-b690-9a820289f148">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-3.1"/>
-			<target type="control" id-ref="#DSP-06"> </target>
+			<target type="control" id-ref="#DSP-06"/>
 		</map>
 		<map uuid="78f99280-2336-4d24-a864-5df5663ac715">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-3.1"/>
-			<target type="control" id-ref="#GRC-03"> </target>
+			<target type="control" id-ref="#GRC-03"/>
 		</map>
 		<map uuid="f8592824-6d34-41dd-8b3a-0b3cc9a52954">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-3.2"/>
-			<target type="control" id-ref="#DSP-03"> </target>
+			<target type="control" id-ref="#DSP-03"/>
 		</map>
 		<map uuid="12955adb-d3ab-4a05-b5f1-086a1ba543bb">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.3"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="2ed2eaf9-f53c-45ee-aa9d-930454686307">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.3"/>
-			<target type="control" id-ref="#IAM-05"> </target>
+			<target type="control" id-ref="#IAM-05"/>
 		</map>
 		<map uuid="02f2174f-0acb-450e-8313-722fea41f381">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.4"/>
-			<target type="control" id-ref="#DSP-16"> </target>
+			<target type="control" id-ref="#DSP-16"/>
 		</map>
 		<map uuid="0f90beb8-8bfc-4380-ab52-f9d163ccaa1c">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.5"/>
-			<target type="control" id-ref="#DSP-02"> </target>
+			<target type="control" id-ref="#DSP-02"/>
 		</map>
 		<map uuid="c0be2e0b-aeff-4fd1-9dd6-fe57d1fdb2b1">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.5"/>
-			<target type="control" id-ref="#DSP-16"> </target>
+			<target type="control" id-ref="#DSP-16"/>
 		</map>
 		<map uuid="91dd6667-6784-4233-98c2-0c1810ead394">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.6"/>
-			<target type="control" id-ref="#CEK-03"> </target>
+			<target type="control" id-ref="#CEK-03"/>
 		</map>
 		<map uuid="222f3372-32b5-4970-82d8-e4a9bdd3075c">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.6"/>
-			<target type="control" id-ref="#UEM-08"> </target>
+			<target type="control" id-ref="#UEM-08"/>
 		</map>
 		<map uuid="824f98e6-913f-4f61-be23-f0cfcd6620b6">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.7"/>
-			<target type="control" id-ref="#DSP-01"> </target>
+			<target type="control" id-ref="#DSP-01"/>
 		</map>
 		<map uuid="2d57f872-16b0-4dd3-88db-e181fc79dae0">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.7"/>
-			<target type="control" id-ref="#DSP-04"> </target>
+			<target type="control" id-ref="#DSP-04"/>
 		</map>
 		<map uuid="b049ec72-f315-4abf-a043-a049927847d0">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.8"/>
-			<target type="control" id-ref="#DSP-05"> </target>
+			<target type="control" id-ref="#DSP-05"/>
 		</map>
 		<map uuid="ec7db17a-fbbd-41b0-b106-5014f2d2ebf4">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.8"/>
-			<target type="control" id-ref="#IVS-03"> </target>
+			<target type="control" id-ref="#IVS-03"/>
 		</map>
 		<map uuid="95ede245-123a-4f42-8c00-97793f90d731">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.10"/>
-			<target type="control" id-ref="#CEK-03"> </target>
+			<target type="control" id-ref="#CEK-03"/>
 		</map>
 		<map uuid="95b082bc-4301-481d-82fa-2787c169e831">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.10"/>
-			<target type="control" id-ref="#DSP-10"> </target>
+			<target type="control" id-ref="#DSP-10"/>
 		</map>
 		<map uuid="9ed3888d-1816-4876-acc8-cfa29571dedb">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.10"/>
-			<target type="control" id-ref="#DSP-10"> </target>
+			<target type="control" id-ref="#DSP-10"/>
 		</map>
 		<map uuid="a9e5e849-f3fa-4778-80b0-b564e78167bb">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.10"/>
-			<target type="control" id-ref="#IVS-03"> </target>
+			<target type="control" id-ref="#IVS-03"/>
 		</map>
 		<map uuid="e2a6e1e3-2e1d-4bbd-9c86-461f0bb495e9">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.11"/>
-			<target type="control" id-ref="#CEK-03"> </target>
+			<target type="control" id-ref="#CEK-03"/>
 		</map>
 		<map uuid="88fa58c5-f271-4ad7-8475-54f3469f1312">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.12"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="042cf8c5-0605-4959-89bc-6d2cf73730aa">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-3.13"/>
-			<target type="control" id-ref="#DSP-10"> </target>
+			<target type="control" id-ref="#DSP-10"/>
 		</map>
 		<map uuid="a0205cf3-f7ab-494d-ba6b-cfdcd123f348">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-3.13"/>
-			<target type="control" id-ref="#UEM-11"> </target>
+			<target type="control" id-ref="#UEM-11"/>
 		</map>
 		<map uuid="46d9b21a-c28f-49f9-ad63-ac82cf6f9070">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.14"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="8c5c5704-d97f-42d0-8791-0d976e45454f">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-3.14"/>
-			<target type="control" id-ref="#IAM-12"> </target>
+			<target type="control" id-ref="#IAM-12"/>
 		</map>
 		<map uuid="cc18b09d-137f-4681-91af-4dd5901eda2a">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-3.14"/>
-			<target type="control" id-ref="#LOG-04"> </target>
+			<target type="control" id-ref="#LOG-04"/>
 		</map>
 		<map uuid="ca35c1e0-4afd-48a0-b908-176dab5fcf83">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-4.1"/>
-			<target type="control" id-ref="#CCC-01"> </target>
+			<target type="control" id-ref="#CCC-01"/>
 		</map>
 		<map uuid="b3611321-9627-43f3-8fe9-5b521105beb2">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-4.1"/>
-			<target type="control" id-ref="#CCC-01"> </target>
+			<target type="control" id-ref="#CCC-01"/>
 		</map>
 		<map uuid="529b0131-1b9c-480e-9910-e4ea925a0052">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-4.1"/>
-			<target type="control" id-ref="#GRC-03"> </target>
+			<target type="control" id-ref="#GRC-03"/>
 		</map>
 		<map uuid="259e07b8-e640-424e-a2be-83c4abd652b7">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-4.1"/>
-			<target type="control" id-ref="#IVS-04"> </target>
+			<target type="control" id-ref="#IVS-04"/>
 		</map>
 		<map uuid="2ac91f70-c2c9-42ad-b969-0d8031835610">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-4.2"/>
-			<target type="control" id-ref="#IVS-04"> </target>
+			<target type="control" id-ref="#IVS-04"/>
 		</map>
 		<map uuid="8328a6ed-4dfd-4577-875c-6d2baf9d1970">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-4.3"/>
-			<target type="control" id-ref="#UEM-06"> </target>
+			<target type="control" id-ref="#UEM-06"/>
 		</map>
 		<map uuid="f23c64ca-30ef-4801-b3a4-e66077d7e1a0">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-4.5"/>
-			<target type="control" id-ref="#UEM-10"> </target>
+			<target type="control" id-ref="#UEM-10"/>
 		</map>
 		<map uuid="9ac4010d-b0ac-453d-8170-1a29f4f78e6d">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-4.11"/>
-			<target type="control" id-ref="#UEM-13"> </target>
+			<target type="control" id-ref="#UEM-13"/>
 		</map>
 		<map uuid="b4b9df39-e015-453f-a877-5052675adf60">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-4.12"/>
-			<target type="control" id-ref="#HRS-04"> </target>
+			<target type="control" id-ref="#HRS-04"/>
 		</map>
 		<map uuid="a2af0058-8daa-4e5c-9a02-90297dcd284c">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-5.1"/>
-			<target type="control" id-ref="#IAM-03"> </target>
+			<target type="control" id-ref="#IAM-03"/>
 		</map>
 		<map uuid="df8c35c6-f421-4b05-ae33-c63ac392a756">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-5.1"/>
-			<target type="control" id-ref="#IAM-08"> </target>
+			<target type="control" id-ref="#IAM-08"/>
 		</map>
 		<map uuid="e690fa8d-a7c2-4475-86a5-89a5fc0a2d37">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-5.1"/>
-			<target type="control" id-ref="#IAM-10"> </target>
+			<target type="control" id-ref="#IAM-10"/>
 		</map>
 		<map uuid="25f18273-feb1-40d7-9921-7427eb596306">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-5.1"/>
-			<target type="control" id-ref="#IAM-16"> </target>
+			<target type="control" id-ref="#IAM-16"/>
 		</map>
 		<map uuid="ddc4998c-89fd-4164-8726-55a944ff3863">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-5.2"/>
-			<target type="control" id-ref="#IAM-02"> </target>
+			<target type="control" id-ref="#IAM-02"/>
 		</map>
 		<map uuid="0925eb00-e45a-42c7-87eb-fee3aa36a234">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-5.4"/>
-			<target type="control" id-ref="#IAM-09"> </target>
+			<target type="control" id-ref="#IAM-09"/>
 		</map>
 		<map uuid="abbf00fc-a5ac-43dd-91c7-d305edc52258">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-5.5"/>
-			<target type="control" id-ref="#IAM-03"> </target>
+			<target type="control" id-ref="#IAM-03"/>
 		</map>
 		<map uuid="41f53f60-f768-42ff-8d15-a7ea92e20450">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.1"/>
-			<target type="control" id-ref="#IAM-01"> </target>
+			<target type="control" id-ref="#IAM-01"/>
 		</map>
 		<map uuid="c0fa155e-9c82-4150-a601-ccf68afa1328">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.1"/>
-			<target type="control" id-ref="#IAM-06"> </target>
+			<target type="control" id-ref="#IAM-06"/>
 		</map>
 		<map uuid="0127c0ad-c57c-4fa7-aa40-322ece347c8f">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.1"/>
-			<target type="control" id-ref="#IAM-07"> </target>
+			<target type="control" id-ref="#IAM-07"/>
 		</map>
 		<map uuid="27b7b4cd-4215-4caa-8fd1-69cfed7bf265">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.2"/>
-			<target type="control" id-ref="#HRS-06"> </target>
+			<target type="control" id-ref="#HRS-06"/>
 		</map>
 		<map uuid="96954b3a-2f03-4ce8-adcf-6b7d92610140">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.2"/>
-			<target type="control" id-ref="#IAM-01"> </target>
+			<target type="control" id-ref="#IAM-01"/>
 		</map>
 		<map uuid="137a4718-3975-4ce2-bab6-7bd0dd8d7b7a">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-6.2"/>
-			<target type="control" id-ref="#IAM-07"> </target>
+			<target type="control" id-ref="#IAM-07"/>
 		</map>
 		<map uuid="31bd8a68-1791-4d9f-99ab-e11de563489e">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.4"/>
-			<target type="control" id-ref="#HRS-04"> </target>
+			<target type="control" id-ref="#HRS-04"/>
 		</map>
 		<map uuid="b5b5068b-2bb9-48f3-805c-c61c54bcbf3f">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.5"/>
-			<target type="control" id-ref="#IAM-10"> </target>
+			<target type="control" id-ref="#IAM-10"/>
 		</map>
 		<map uuid="365c9f4f-d112-4a6e-8d18-a62189d5651b">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.5"/>
-			<target type="control" id-ref="#IAM-14"> </target>
+			<target type="control" id-ref="#IAM-14"/>
 		</map>
 		<map uuid="a38dee63-c5c0-4d57-9756-f0d3ddd3f6d6">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-6.6"/>
-			<target type="control" id-ref="#IAM-01"> </target>
+			<target type="control" id-ref="#IAM-01"/>
 		</map>
 		<map uuid="c0baccf0-a438-4d9e-9e81-d4501971d582">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-6.8"/>
-			<target type="control" id-ref="#IAM-04"> </target>
+			<target type="control" id-ref="#IAM-04"/>
 		</map>
 		<map uuid="4b90b83e-ca8f-4d94-957c-6c0212e763e6">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-6.8"/>
-			<target type="control" id-ref="#IAM-05"> </target>
+			<target type="control" id-ref="#IAM-05"/>
 		</map>
 		<map uuid="4f324b27-3b58-49a4-a25d-779685b1023d">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-6.8"/>
-			<target type="control" id-ref="#IAM-16"> </target>
+			<target type="control" id-ref="#IAM-16"/>
 		</map>
 		<map uuid="3f109fc9-68f5-4f70-9290-42ed674d59ce">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-7.1"/>
-			<target type="control" id-ref="#TVM-01"> </target>
+			<target type="control" id-ref="#TVM-01"/>
 		</map>
 		<map uuid="6f13ff2a-7e64-492e-99ee-aabbe79b37e1">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-7.1"/>
-			<target type="control" id-ref="#TVM-07"> </target>
+			<target type="control" id-ref="#TVM-07"/>
 		</map>
 		<map uuid="af47907d-4def-4a92-adf8-b97f588d37b9">
 			<relationship>supserset</relationship>
 			<source type="control" id-ref="#cisc-7.1"/>
-			<target type="control" id-ref="#TVM-09"> </target>
+			<target type="control" id-ref="#TVM-09"/>
 		</map>
 		<map uuid="5352bb00-3207-455e-9972-7c0ed30db637">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-7.2"/>
-			<target type="control" id-ref="#A&amp;Amp;A-03"> </target>
+			<target type="control" id-ref="#A&amp;Amp;A-03"/>
 		</map>
 		<map uuid="44725d67-6f5a-4ab4-8ea2-eca43418f077">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-7.2"/>
-			<target type="control" id-ref="#TVM-08"> </target>
+			<target type="control" id-ref="#TVM-08"/>
 		</map>
 		<map uuid="d4add505-1cd1-441c-b28b-f6afcdc96d3c">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-7.2"/>
-			<target type="control" id-ref="#TVM-10"> </target>
+			<target type="control" id-ref="#TVM-10"/>
 		</map>
 		<map uuid="06c281c0-eb00-44a3-8b62-ad36c2644e27">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-7.3"/>
-			<target type="control" id-ref="#UEM-07"> </target>
+			<target type="control" id-ref="#UEM-07"/>
 		</map>
 		<map uuid="dbf050b6-cb7f-4d8b-8989-d4dbcd4efe34">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-7.4"/>
-			<target type="control" id-ref="#UEM-03"> </target>
+			<target type="control" id-ref="#UEM-03"/>
 		</map>
 		<map uuid="c178e1f7-5581-437d-8505-082495c16f74">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-7.5"/>
-			<target type="control" id-ref="#TVM-07"> </target>
+			<target type="control" id-ref="#TVM-07"/>
 		</map>
 		<map uuid="295ef882-ba37-4889-9a49-f43e7141d115">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-7.6"/>
-			<target type="control" id-ref="#TVM-07"> </target>
+			<target type="control" id-ref="#TVM-07"/>
 		</map>
 		<map uuid="1c8344e7-3819-4d3f-a587-aea14c1db0e1">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-7.7"/>
-			<target type="control" id-ref="#TVM-03"> </target>
+			<target type="control" id-ref="#TVM-03"/>
 		</map>
 		<map uuid="de1c4e0f-f6a0-4302-b161-1e5bdfd34e04">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-8.1"/>
-			<target type="control" id-ref="#A&amp;A-01"> </target>
+			<target type="control" id-ref="#A&amp;A-01"/>
 		</map>
 		<map uuid="56b70c69-e466-4b79-9ad9-971d401f1bc3">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-8.1"/>
-			<target type="control" id-ref="#LOG-01"> </target>
+			<target type="control" id-ref="#LOG-01"/>
 		</map>
 		<map uuid="d9b2134c-f84e-459a-9f97-71d224f13462">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-8.1"/>
-			<target type="control" id-ref="#LOG-07"> </target>
+			<target type="control" id-ref="#LOG-07"/>
 		</map>
 		<map uuid="84db0645-9b8d-4efe-893d-ffe2cb3867c8">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-8.2"/>
-			<target type="control" id-ref="#LOG-08"> </target>
+			<target type="control" id-ref="#LOG-08"/>
 		</map>
 		<map uuid="e91647e9-de63-419e-8b69-8021d073c49c">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-8.4"/>
-			<target type="control" id-ref="#LOG-06"> </target>
+			<target type="control" id-ref="#LOG-06"/>
 		</map>
 		<map uuid="24672f5a-38f5-49b2-9427-d6205a703a95">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-8.5"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="cb7bdf51-7d8d-4575-9080-3d74266a4956">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-8.5"/>
-			<target type="control" id-ref="#LOG-03"> </target>
+			<target type="control" id-ref="#LOG-03"/>
 		</map>
 		<map uuid="cd0d9304-d263-4b15-a940-e29ce11a5952">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-8.10"/>
-			<target type="control" id-ref="#LOG-02"> </target>
+			<target type="control" id-ref="#LOG-02"/>
 		</map>
 		<map uuid="cb23c6be-2b68-422f-b96a-4649ac767cb7">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-8.11"/>
-			<target type="control" id-ref="#LOG-05"> </target>
+			<target type="control" id-ref="#LOG-05"/>
 		</map>
 		<map uuid="637f084d-07f0-4f1c-aefb-352dc60127ad">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-8.11"/>
-			<target type="control" id-ref="#LOG-13"> </target>
+			<target type="control" id-ref="#LOG-13"/>
 		</map>
 		<map uuid="ce24c911-24de-4db6-b513-c5b56e43e9e8">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-9.7"/>
-			<target type="control" id-ref="#TVM-02"> </target>
+			<target type="control" id-ref="#TVM-02"/>
 		</map>
 		<map uuid="071a7f32-b337-4907-8971-057b6d51dd85">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-10.1"/>
-			<target type="control" id-ref="#TVM-02"> </target>
+			<target type="control" id-ref="#TVM-02"/>
 		</map>
 		<map uuid="e7507be2-11d7-4e3c-8c7b-506026eb38ef">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-10.1"/>
-			<target type="control" id-ref="#UEM-09"> </target>
+			<target type="control" id-ref="#UEM-09"/>
 		</map>
 		<map uuid="429dec9a-09e9-48d7-a1b9-6e28f88b8a76">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-10.2"/>
-			<target type="control" id-ref="#TVM-04"> </target>
+			<target type="control" id-ref="#TVM-04"/>
 		</map>
 		<map uuid="08f4e56c-fe2d-447f-aa5b-287b1554079d">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-12.2"/>
-			<target type="control" id-ref="#DSP-07"> </target>
+			<target type="control" id-ref="#DSP-07"/>
 		</map>
 		<map uuid="58d38197-854b-4906-99f9-6a6dace91752">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-12.2"/>
-			<target type="control" id-ref="#IVS-03"> </target>
+			<target type="control" id-ref="#IVS-03"/>
 		</map>
 		<map uuid="957b9cd4-47c5-4f0b-b92e-7e8d1cf7c253">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-12.4"/>
-			<target type="control" id-ref="#IVS-08"> </target>
+			<target type="control" id-ref="#IVS-08"/>
 		</map>
 		<map uuid="b2f139c5-382e-4838-ad66-8e2605cbf2b9">
 			<relationship>intersects</relationship>
 			<source type="control" id-ref="#cisc-12.5"/>
-			<target type="control" id-ref="#IAM-14"> </target>
+			<target type="control" id-ref="#IAM-14"/>
 		</map>
 		<map uuid="5a5149e7-f522-4871-88a5-5134aeb64d6f">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-12.7"/>
-			<target type="control" id-ref="#HRS-04"> </target>
+			<target type="control" id-ref="#HRS-04"/>
 		</map>
 		<map uuid="5bddbe2f-cd2e-4133-a3c9-b6602876a14a">
 			<relationship>intersects</relationship>
 			<source type="control" id-ref="#cisc-12.7"/>
-			<target type="control" id-ref="#IAM-14"> </target>
+			<target type="control" id-ref="#IAM-14"/>
 		</map>
 		<map uuid="e4dc90c5-f6e8-4262-9f81-e91f77f85628">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-13.1"/>
-			<target type="control" id-ref="#LOG-03"> </target>
+			<target type="control" id-ref="#LOG-03"/>
 		</map>
 		<map uuid="8a792030-f33b-4ae6-86a4-5887a8da25ea">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.1"/>
-			<target type="control" id-ref="#SEF-01"> </target>
+			<target type="control" id-ref="#SEF-01"/>
 		</map>
 		<map uuid="8898cb4d-bd5a-4579-976f-469801b77e44">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.3"/>
-			<target type="control" id-ref="#IVS-09"> </target>
+			<target type="control" id-ref="#IVS-09"/>
 		</map>
 		<map uuid="9e50aa9e-ef48-4125-94b7-f8a5af255e5c">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.5"/>
-			<target type="control" id-ref="#HRS-04"> </target>
+			<target type="control" id-ref="#HRS-04"/>
 		</map>
 		<map uuid="e46c826a-47ca-409d-aeea-67c857d48282">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.6"/>
-			<target type="control" id-ref="#IVS-03"> </target>
+			<target type="control" id-ref="#IVS-03"/>
 		</map>
 		<map uuid="7c7708cb-6fd7-4e04-a897-5095745768f7">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.8"/>
-			<target type="control" id-ref="#IVS-09"> </target>
+			<target type="control" id-ref="#IVS-09"/>
 		</map>
 		<map uuid="0d77eccd-3df7-4c41-9299-25b58a73491c">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-13.9"/>
-			<target type="control" id-ref="#IVS-03"> </target>
+			<target type="control" id-ref="#IVS-03"/>
 		</map>
 		<map uuid="b6bfa101-06bf-4169-8711-114d67f93cbf">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-14.1"/>
-			<target type="control" id-ref="#GRC-05"> </target>
+			<target type="control" id-ref="#GRC-05"/>
 		</map>
 		<map uuid="8bbac20f-5444-4664-ade0-2150798f1327">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-14.1"/>
-			<target type="control" id-ref="#HRS-11"> </target>
+			<target type="control" id-ref="#HRS-11"/>
 		</map>
 		<map uuid="4e546bea-9675-4c6a-8ce0-94d11fb0a4bb">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-14.1"/>
-			<target type="control" id-ref="#GRC-03"> </target>
+			<target type="control" id-ref="#GRC-03"/>
 		</map>
 		<map uuid="531ace4b-35c3-4d8c-b805-c224ada6a83d">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.2"/>
-			<target type="control" id-ref="#HRS-11"> </target>
+			<target type="control" id-ref="#HRS-11"/>
 		</map>
 		<map uuid="a0074c66-480c-4cb7-badc-0c9fd5f785a2">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.3"/>
-			<target type="control" id-ref="#GRC-05"> </target>
+			<target type="control" id-ref="#GRC-05"/>
 		</map>
 		<map uuid="29652793-13aa-4b30-a9d9-585279a0c115">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.3"/>
-			<target type="control" id-ref="#HRS-11"> </target>
+			<target type="control" id-ref="#HRS-11"/>
 		</map>
 		<map uuid="e8a8e264-1044-4e76-97c8-42688bccba09">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.4"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="57b39cd8-2494-4336-88af-ca19b8f1d5e8">
 			<relationship>intersects</relationship>
 			<source type="control" id-ref="#cisc-14.4"/>
-			<target type="control" id-ref="#GRC-01"> </target>
+			<target type="control" id-ref="#GRC-01"/>
 		</map>
 		<map uuid="90f58a67-9e97-4c54-add0-21ece8adc949">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-14.4"/>
-			<target type="control" id-ref="#HRS-03"> </target>
+			<target type="control" id-ref="#HRS-03"/>
 		</map>
 		<map uuid="7ac6b858-3106-495d-8bf4-23902dcfcf71">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-14.4"/>
-			<target type="control" id-ref="#HRS-12"> </target>
+			<target type="control" id-ref="#HRS-12"/>
 		</map>
 		<map uuid="42cc1ba2-362d-43cc-b441-7bbad551a673">
 			<relationship>intersects</relationship>
 			<source type="control" id-ref="#cisc-14.5"/>
-			<target type="control" id-ref="#GRC-01"> </target>
+			<target type="control" id-ref="#GRC-01"/>
 		</map>
 		<map uuid="a6f9056c-ce90-4145-bd86-143ea34e3671">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.5"/>
-			<target type="control" id-ref="#HRS-11"> </target>
+			<target type="control" id-ref="#HRS-11"/>
 		</map>
 		<map uuid="c0c778df-a55d-48b1-b1a0-5ec7b4dfb90f">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.6"/>
-			<target type="control" id-ref="#HRS-11"> </target>
+			<target type="control" id-ref="#HRS-11"/>
 		</map>
 		<map uuid="ff0525a2-b9c5-4a2e-a2ac-bacd99a8aa67">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.7"/>
-			<target type="control" id-ref="#DSP-17"> </target>
+			<target type="control" id-ref="#DSP-17"/>
 		</map>
 		<map uuid="7cdb93c4-e295-476c-8850-b46941b6ea74">
 			<relationship>intersects</relationship>
 			<source type="control" id-ref="#cisc-14.8"/>
-			<target type="control" id-ref="#GRC-01"> </target>
+			<target type="control" id-ref="#GRC-01"/>
 		</map>
 		<map uuid="1a7b7c1e-b876-41a9-8479-1bf50ceae9f9">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.8"/>
-			<target type="control" id-ref="#HRS-04"> </target>
+			<target type="control" id-ref="#HRS-04"/>
 		</map>
 		<map uuid="fa93b58d-400e-43d3-bf26-ff57d5a75de2">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-14.9"/>
-			<target type="control" id-ref="#HRS-09"> </target>
+			<target type="control" id-ref="#HRS-09"/>
 		</map>
 		<map uuid="832316fd-c936-4149-b52a-29cd12e180c5">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-14.9"/>
-			<target type="control" id-ref="#HRS-12"> </target>
+			<target type="control" id-ref="#HRS-12"/>
 		</map>
 		<map uuid="f0aa30e3-c629-4bed-b1d0-379a45217d7b">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-15.1"/>
-			<target type="control" id-ref="#STA-07"> </target>
+			<target type="control" id-ref="#STA-07"/>
 		</map>
 		<map uuid="24c77842-ad8b-484b-9eba-64be619a8b51">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-15.3"/>
-			<target type="control" id-ref="#GRC-02"> </target>
+			<target type="control" id-ref="#GRC-02"/>
 		</map>
 		<map uuid="d6a4b5b7-bda3-47dd-9eb9-f3b8cc2b3050">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-15.3"/>
-			<target type="control" id-ref="#STA-08"> </target>
+			<target type="control" id-ref="#STA-08"/>
 		</map>
 		<map uuid="0d2ce502-9913-492c-9dbc-0b84e2a86694">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-15.4"/>
-			<target type="control" id-ref="#STA-09"> </target>
+			<target type="control" id-ref="#STA-09"/>
 		</map>
 		<map uuid="a31ec15b-5b56-4c01-a658-6626655ebb69">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-15.4"/>
-			<target type="control" id-ref="#STA-10"> </target>
+			<target type="control" id-ref="#STA-10"/>
 		</map>
 		<map uuid="0998c607-88bf-4d55-bbe8-9707b6e0d0ae">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-15.4"/>
-			<target type="control" id-ref="#UEM-14"> </target>
+			<target type="control" id-ref="#UEM-14"/>
 		</map>
 		<map uuid="40d9de65-15b4-42dc-8db6-3360e76dee22">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-15.5"/>
-			<target type="control" id-ref="#STA-12"> </target>
+			<target type="control" id-ref="#STA-12"/>
 		</map>
 		<map uuid="9152d107-c4cb-4cf4-87f3-d1a15decc73a">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-15.5"/>
-			<target type="control" id-ref="#STA-13"> </target>
+			<target type="control" id-ref="#STA-13"/>
 		</map>
 		<map uuid="d36fe370-5d14-4983-8123-109eeac3b29d">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-15.6"/>
-			<target type="control" id-ref="#STA-14"> </target>
+			<target type="control" id-ref="#STA-14"/>
 		</map>
 		<map uuid="b64583a0-da87-4636-a8b8-6d2b7d7ac319">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-16.1"/>
-			<target type="control" id-ref="#AIS-01"> </target>
+			<target type="control" id-ref="#AIS-01"/>
 		</map>
 		<map uuid="f45bd4a4-1740-402c-bfdb-ec84f88df42f">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-16.1"/>
-			<target type="control" id-ref="#AIS-04"> </target>
+			<target type="control" id-ref="#AIS-04"/>
 		</map>
 		<map uuid="b0f3dc8f-2a62-4f2f-97f7-f58d64fe23ea">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-16.2"/>
-			<target type="control" id-ref="#AIS-03"> </target>
+			<target type="control" id-ref="#AIS-03"/>
 		</map>
 		<map uuid="067f2fc0-1df3-4cb4-9bc4-2387f720aef4">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-16.2"/>
-			<target type="control" id-ref="#AIS-07"> </target>
+			<target type="control" id-ref="#AIS-07"/>
 		</map>
 		<map uuid="ef8add2b-e0f2-4ba4-85fa-0f8c9d1c1c29">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-16.4"/>
-			<target type="control" id-ref="#GRC-02"> </target>
+			<target type="control" id-ref="#GRC-02"/>
 		</map>
 		<map uuid="fe022e31-b394-479a-9f03-a21261a0493d">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-16.6"/>
-			<target type="control" id-ref="#AIS-07"> </target>
+			<target type="control" id-ref="#AIS-07"/>
 		</map>
 		<map uuid="cb2e3386-c8f0-4d70-aaec-3052ebe358f1">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-16.6"/>
-			<target type="control" id-ref="#TVM-08"> </target>
+			<target type="control" id-ref="#TVM-08"/>
 		</map>
 		<map uuid="bda3184b-060b-4764-b9a1-0bb8e59fcca8">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-16.7"/>
-			<target type="control" id-ref="#AIS-02"> </target>
+			<target type="control" id-ref="#AIS-02"/>
 		</map>
 		<map uuid="c0cde3e1-aef6-4d77-a02a-8cc983d7e5ec">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-16.8"/>
-			<target type="control" id-ref="#IVS-05"> </target>
+			<target type="control" id-ref="#IVS-05"/>
 		</map>
 		<map uuid="71f1432c-18ad-4f85-a750-53d4e4a9dc12">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-16.10"/>
-			<target type="control" id-ref="#DSP-07"> </target>
+			<target type="control" id-ref="#DSP-07"/>
 		</map>
 		<map uuid="9bf8c233-d453-4013-9493-13b706c73da9">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-16.12"/>
-			<target type="control" id-ref="#AIS-05"> </target>
+			<target type="control" id-ref="#AIS-05"/>
 		</map>
 		<map uuid="bd9f9079-083e-47bc-b2ec-a8824737c489">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-16.13"/>
-			<target type="control" id-ref="#AIS-05"> </target>
+			<target type="control" id-ref="#AIS-05"/>
 		</map>
 		<map uuid="1c7e970c-3807-4a29-aa72-74e1b1b6358a">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-17.1"/>
-			<target type="control" id-ref="#BCR-01"> </target>
+			<target type="control" id-ref="#BCR-01"/>
 		</map>
 		<map uuid="71c0bf75-0466-458b-a842-68af5f3cdf1b">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-17.1"/>
-			<target type="control" id-ref="#SEF-03"> </target>
+			<target type="control" id-ref="#SEF-03"/>
 		</map>
 		<map uuid="0fe69621-ddcd-4f54-95f2-5a3a329eec9e">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-17.2"/>
-			<target type="control" id-ref="#SEF-08"> </target>
+			<target type="control" id-ref="#SEF-08"/>
 		</map>
 		<map uuid="5a13e251-3a33-4c27-a26a-9d0b9917f60e">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-17.2"/>
-			<target type="control" id-ref="#SEF-07"> </target>
+			<target type="control" id-ref="#SEF-07"/>
 		</map>
 		<map uuid="5600b5b0-a870-4ad9-a673-eef11c51deca">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-17.4"/>
-			<target type="control" id-ref="#SEF-01"> </target>
+			<target type="control" id-ref="#SEF-01"/>
 		</map>
 		<map uuid="6807754f-2032-4ad5-8a85-b9d63c26402f">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-17.4"/>
-			<target type="control" id-ref="#SEF-02"> </target>
+			<target type="control" id-ref="#SEF-02"/>
 		</map>
 		<map uuid="c89042bb-922d-42b9-be2c-17588e60be9a">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-17.4"/>
-			<target type="control" id-ref="#SEF-03"> </target>
+			<target type="control" id-ref="#SEF-03"/>
 		</map>
 		<map uuid="4d084a7c-e27a-4e8d-a00b-f5afeb9f5d9e">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-17.4"/>
-			<target type="control" id-ref="#SEF-06"> </target>
+			<target type="control" id-ref="#SEF-06"/>
 		</map>
 		<map uuid="1cb4a029-07ee-4817-ab32-289db9c7ba2e">
 			<relationship>superset-of</relationship>
 			<source type="control" id-ref="#cisc-17.4"/>
-			<target type="control" id-ref="#GRC-03"> </target>
+			<target type="control" id-ref="#GRC-03"/>
 		</map>
 		<map uuid="0c54052b-fe01-44aa-aef5-a30fe489e838">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-17.5"/>
-			<target type="control" id-ref="#SEF-03"> </target>
+			<target type="control" id-ref="#SEF-03"/>
 		</map>
 		<map uuid="cb8d447b-c97a-45a3-8cd4-a61f4466a35d">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-17.7"/>
-			<target type="control" id-ref="#SEF-04"> </target>
+			<target type="control" id-ref="#SEF-04"/>
 		</map>
 		<map uuid="a1713855-8283-4f2d-87e8-cf77de583483">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-17.9"/>
-			<target type="control" id-ref="#SEF-05"> </target>
+			<target type="control" id-ref="#SEF-05"/>
 		</map>
 		<map uuid="838991d0-b2f2-4c9e-b370-01ff63c85061">
 			<relationship>equivalent-to</relationship>
 			<source type="control" id-ref="#cisc-18.1"/>
-			<target type="control" id-ref="#TVM-06"> </target>
+			<target type="control" id-ref="#TVM-06"/>
 		</map>
 		<map uuid="19299403-6122-4d97-b5f1-907137699c6b">
 			<relationship>subset-of</relationship>
 			<source type="control" id-ref="#cisc-18.3"/>
-			<target type="control" id-ref="#TVM-08"> </target>
+			<target type="control" id-ref="#TVM-08"/>
 		</map>
 	</mapping>
 	<back-matter>

--- a/CCM_CISControlsv8_Mapping.xml
+++ b/CCM_CISControlsv8_Mapping.xml
@@ -11,7 +11,7 @@
 	</metadata>
 	<mapping uuid="9eb2019c-f3be-4f96-947e-58876a46b2a9">
 		<!-- update UID -->
-		<source-resource type="catalog" href="#5ca20d92-aa27-462f-be0d-51385e55149a"/>
+		<source-resource type="catalog" href="#a84961de-55ae-4bf3-a2d3-86cc32b651af"/>
 		<!-- #update UID -->
 		<target-resource type="catalog" href="#711085f6-c390-4b25-b5f1-30066a56073d"/>
 		<map uuid="6a9a1161-770e-4556-9740-41e1809e14ea">
@@ -778,10 +778,8 @@
 			<rlink href="cis-controls-v8_OSCAL-1.0.xml" media-type="application/oscal+xml"/>
 		</resource>
 		<resource uuid="711085f6-c390-4b25-b5f1-30066a56073d">
-			<!-- TODO: this rlink needs to point to the CCM. -->
-			<rlink
-				href="https://github.com/usnistgov/oscal-content/raw/main/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml"
-				media-type="application/oscal+xml"/>
+			<!-- TODO: add an rlink to point to the CCM when an OSCAL version is made publiclly available. -->
+			<!-- TODO: It may be necessary to update the CCM identifiers to the ones used in the CCM OSCAL content. -->
 		</resource>
 	</back-matter>
 </mapping-collection>

--- a/CCM_CISControlsv8_Mapping.xml
+++ b/CCM_CISControlsv8_Mapping.xml
@@ -778,8 +778,7 @@
 			<rlink href="cis-controls-v8_OSCAL-1.0.xml" media-type="application/oscal+xml"/>
 		</resource>
 		<resource uuid="711085f6-c390-4b25-b5f1-30066a56073d">
-			<!-- TODO: add an rlink to point to the CCM when an OSCAL version is made publiclly available. -->
-			<!-- TODO: It may be necessary to update the CCM identifiers to the ones used in the CCM OSCAL content. -->
+			<!-- TODO: add an rlink to point to the CCM when an OSCAL version is made publiclly available (https://github.com/CISecurity/CISControls_OSCAL/issues/4). -->
 		</resource>
 	</back-matter>
 </mapping-collection>

--- a/CCM_CISControlsv8_Mapping.xml
+++ b/CCM_CISControlsv8_Mapping.xml
@@ -16,7 +16,7 @@
 		<target-resource type="catalog" href="#711085f6-c390-4b25-b5f1-30066a56073d"/>
 		<map uuid="6a9a1161-770e-4556-9740-41e1809e14ea">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-1.1"/>
+			<source type="control" id-ref="#cisc-1.1"/>
 			<target type="control" id-ref="#UEM-04">
 				<!-- TODO: consider a way to reference parameters allowing the review period of at least bi-annually to be described -->
 				<!-- <using-param id="cm-08_odp.02">at least bi-annually</using-param>-->
@@ -29,747 +29,747 @@
 		</map>
 		<map uuid="383ee0c0-8739-4e61-b33e-f6f92b0bc7ed">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-1.1"/>
+			<source type="control" id-ref="#cisc-1.1"/>
 			<target type="control" id-ref="#UEM-04"> </target>
 		</map>
 		<map uuid="23e6fbec-3e36-42d1-aff5-98f28145ae32">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-1.3"/>
+			<source type="control" id-ref="#cisc-1.3"/>
 			<target type="control" id-ref="#UEM-05"> </target>
 		</map>
 		<map uuid="2162f11d-f51d-4164-80fc-2c80241d8c35">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-2.1"/>
+			<source type="control" id-ref="#cisc-2.1"/>
 			<target type="control" id-ref="#UEM-02"> </target>
 		</map>
 		<map uuid="a350cef1-140f-4576-92a9-7a79db43bf2b">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.1"/>
+			<source type="control" id-ref="#cisc-3.1"/>
 			<target type="control" id-ref="#DSP-01"> </target>
 		</map>
 		<map uuid="14f99cad-40b8-4087-b690-9a820289f148">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-3.1"/>
+			<source type="control" id-ref="#cisc-3.1"/>
 			<target type="control" id-ref="#DSP-06"> </target>
 		</map>
 		<map uuid="78f99280-2336-4d24-a864-5df5663ac715">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-3.1"/>
+			<source type="control" id-ref="#cisc-3.1"/>
 			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="f8592824-6d34-41dd-8b3a-0b3cc9a52954">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-3.2"/>
+			<source type="control" id-ref="#cisc-3.2"/>
 			<target type="control" id-ref="#DSP-03"> </target>
 		</map>
 		<map uuid="12955adb-d3ab-4a05-b5f1-086a1ba543bb">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.3"/>
+			<source type="control" id-ref="#cisc-3.3"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="2ed2eaf9-f53c-45ee-aa9d-930454686307">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.3"/>
+			<source type="control" id-ref="#cisc-3.3"/>
 			<target type="control" id-ref="#IAM-05"> </target>
 		</map>
 		<map uuid="02f2174f-0acb-450e-8313-722fea41f381">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.4"/>
+			<source type="control" id-ref="#cisc-3.4"/>
 			<target type="control" id-ref="#DSP-16"> </target>
 		</map>
 		<map uuid="0f90beb8-8bfc-4380-ab52-f9d163ccaa1c">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.5"/>
+			<source type="control" id-ref="#cisc-3.5"/>
 			<target type="control" id-ref="#DSP-02"> </target>
 		</map>
 		<map uuid="c0be2e0b-aeff-4fd1-9dd6-fe57d1fdb2b1">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.5"/>
+			<source type="control" id-ref="#cisc-3.5"/>
 			<target type="control" id-ref="#DSP-16"> </target>
 		</map>
 		<map uuid="91dd6667-6784-4233-98c2-0c1810ead394">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.6"/>
+			<source type="control" id-ref="#cisc-3.6"/>
 			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="222f3372-32b5-4970-82d8-e4a9bdd3075c">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.6"/>
+			<source type="control" id-ref="#cisc-3.6"/>
 			<target type="control" id-ref="#UEM-08"> </target>
 		</map>
 		<map uuid="824f98e6-913f-4f61-be23-f0cfcd6620b6">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.7"/>
+			<source type="control" id-ref="#cisc-3.7"/>
 			<target type="control" id-ref="#DSP-01"> </target>
 		</map>
 		<map uuid="2d57f872-16b0-4dd3-88db-e181fc79dae0">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.7"/>
+			<source type="control" id-ref="#cisc-3.7"/>
 			<target type="control" id-ref="#DSP-04"> </target>
 		</map>
 		<map uuid="b049ec72-f315-4abf-a043-a049927847d0">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.8"/>
+			<source type="control" id-ref="#cisc-3.8"/>
 			<target type="control" id-ref="#DSP-05"> </target>
 		</map>
 		<map uuid="ec7db17a-fbbd-41b0-b106-5014f2d2ebf4">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.8"/>
+			<source type="control" id-ref="#cisc-3.8"/>
 			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="95ede245-123a-4f42-8c00-97793f90d731">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.10"/>
+			<source type="control" id-ref="#cisc-3.10"/>
 			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="95b082bc-4301-481d-82fa-2787c169e831">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.10"/>
+			<source type="control" id-ref="#cisc-3.10"/>
 			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="9ed3888d-1816-4876-acc8-cfa29571dedb">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.10"/>
+			<source type="control" id-ref="#cisc-3.10"/>
 			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="a9e5e849-f3fa-4778-80b0-b564e78167bb">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.10"/>
+			<source type="control" id-ref="#cisc-3.10"/>
 			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="e2a6e1e3-2e1d-4bbd-9c86-461f0bb495e9">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.11"/>
+			<source type="control" id-ref="#cisc-3.11"/>
 			<target type="control" id-ref="#CEK-03"> </target>
 		</map>
 		<map uuid="88fa58c5-f271-4ad7-8475-54f3469f1312">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.12"/>
+			<source type="control" id-ref="#cisc-3.12"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="042cf8c5-0605-4959-89bc-6d2cf73730aa">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-3.13"/>
+			<source type="control" id-ref="#cisc-3.13"/>
 			<target type="control" id-ref="#DSP-10"> </target>
 		</map>
 		<map uuid="a0205cf3-f7ab-494d-ba6b-cfdcd123f348">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-3.13"/>
+			<source type="control" id-ref="#cisc-3.13"/>
 			<target type="control" id-ref="#UEM-11"> </target>
 		</map>
 		<map uuid="46d9b21a-c28f-49f9-ad63-ac82cf6f9070">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.14"/>
+			<source type="control" id-ref="#cisc-3.14"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="8c5c5704-d97f-42d0-8791-0d976e45454f">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-3.14"/>
+			<source type="control" id-ref="#cisc-3.14"/>
 			<target type="control" id-ref="#IAM-12"> </target>
 		</map>
 		<map uuid="cc18b09d-137f-4681-91af-4dd5901eda2a">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-3.14"/>
+			<source type="control" id-ref="#cisc-3.14"/>
 			<target type="control" id-ref="#LOG-04"> </target>
 		</map>
 		<map uuid="ca35c1e0-4afd-48a0-b908-176dab5fcf83">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-4.1"/>
+			<source type="control" id-ref="#cisc-4.1"/>
 			<target type="control" id-ref="#CCC-01"> </target>
 		</map>
 		<map uuid="b3611321-9627-43f3-8fe9-5b521105beb2">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-4.1"/>
+			<source type="control" id-ref="#cisc-4.1"/>
 			<target type="control" id-ref="#CCC-01"> </target>
 		</map>
 		<map uuid="529b0131-1b9c-480e-9910-e4ea925a0052">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-4.1"/>
+			<source type="control" id-ref="#cisc-4.1"/>
 			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="259e07b8-e640-424e-a2be-83c4abd652b7">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-4.1"/>
+			<source type="control" id-ref="#cisc-4.1"/>
 			<target type="control" id-ref="#IVS-04"> </target>
 		</map>
 		<map uuid="2ac91f70-c2c9-42ad-b969-0d8031835610">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-4.2"/>
+			<source type="control" id-ref="#cisc-4.2"/>
 			<target type="control" id-ref="#IVS-04"> </target>
 		</map>
 		<map uuid="8328a6ed-4dfd-4577-875c-6d2baf9d1970">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-4.3"/>
+			<source type="control" id-ref="#cisc-4.3"/>
 			<target type="control" id-ref="#UEM-06"> </target>
 		</map>
 		<map uuid="f23c64ca-30ef-4801-b3a4-e66077d7e1a0">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-4.5"/>
+			<source type="control" id-ref="#cisc-4.5"/>
 			<target type="control" id-ref="#UEM-10"> </target>
 		</map>
 		<map uuid="9ac4010d-b0ac-453d-8170-1a29f4f78e6d">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-4.11"/>
+			<source type="control" id-ref="#cisc-4.11"/>
 			<target type="control" id-ref="#UEM-13"> </target>
 		</map>
 		<map uuid="b4b9df39-e015-453f-a877-5052675adf60">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-4.12"/>
+			<source type="control" id-ref="#cisc-4.12"/>
 			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="a2af0058-8daa-4e5c-9a02-90297dcd284c">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-5.1"/>
+			<source type="control" id-ref="#cisc-5.1"/>
 			<target type="control" id-ref="#IAM-03"> </target>
 		</map>
 		<map uuid="df8c35c6-f421-4b05-ae33-c63ac392a756">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-5.1"/>
+			<source type="control" id-ref="#cisc-5.1"/>
 			<target type="control" id-ref="#IAM-08"> </target>
 		</map>
 		<map uuid="e690fa8d-a7c2-4475-86a5-89a5fc0a2d37">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-5.1"/>
+			<source type="control" id-ref="#cisc-5.1"/>
 			<target type="control" id-ref="#IAM-10"> </target>
 		</map>
 		<map uuid="25f18273-feb1-40d7-9921-7427eb596306">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-5.1"/>
+			<source type="control" id-ref="#cisc-5.1"/>
 			<target type="control" id-ref="#IAM-16"> </target>
 		</map>
 		<map uuid="ddc4998c-89fd-4164-8726-55a944ff3863">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-5.2"/>
+			<source type="control" id-ref="#cisc-5.2"/>
 			<target type="control" id-ref="#IAM-02"> </target>
 		</map>
 		<map uuid="0925eb00-e45a-42c7-87eb-fee3aa36a234">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-5.4"/>
+			<source type="control" id-ref="#cisc-5.4"/>
 			<target type="control" id-ref="#IAM-09"> </target>
 		</map>
 		<map uuid="abbf00fc-a5ac-43dd-91c7-d305edc52258">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-5.5"/>
+			<source type="control" id-ref="#cisc-5.5"/>
 			<target type="control" id-ref="#IAM-03"> </target>
 		</map>
 		<map uuid="41f53f60-f768-42ff-8d15-a7ea92e20450">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.1"/>
+			<source type="control" id-ref="#cisc-6.1"/>
 			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="c0fa155e-9c82-4150-a601-ccf68afa1328">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.1"/>
+			<source type="control" id-ref="#cisc-6.1"/>
 			<target type="control" id-ref="#IAM-06"> </target>
 		</map>
 		<map uuid="0127c0ad-c57c-4fa7-aa40-322ece347c8f">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.1"/>
+			<source type="control" id-ref="#cisc-6.1"/>
 			<target type="control" id-ref="#IAM-07"> </target>
 		</map>
 		<map uuid="27b7b4cd-4215-4caa-8fd1-69cfed7bf265">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.2"/>
+			<source type="control" id-ref="#cisc-6.2"/>
 			<target type="control" id-ref="#HRS-06"> </target>
 		</map>
 		<map uuid="96954b3a-2f03-4ce8-adcf-6b7d92610140">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.2"/>
+			<source type="control" id-ref="#cisc-6.2"/>
 			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="137a4718-3975-4ce2-bab6-7bd0dd8d7b7a">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-6.2"/>
+			<source type="control" id-ref="#cisc-6.2"/>
 			<target type="control" id-ref="#IAM-07"> </target>
 		</map>
 		<map uuid="31bd8a68-1791-4d9f-99ab-e11de563489e">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.4"/>
+			<source type="control" id-ref="#cisc-6.4"/>
 			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="b5b5068b-2bb9-48f3-805c-c61c54bcbf3f">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.5"/>
+			<source type="control" id-ref="#cisc-6.5"/>
 			<target type="control" id-ref="#IAM-10"> </target>
 		</map>
 		<map uuid="365c9f4f-d112-4a6e-8d18-a62189d5651b">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.5"/>
+			<source type="control" id-ref="#cisc-6.5"/>
 			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="a38dee63-c5c0-4d57-9756-f0d3ddd3f6d6">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-6.6"/>
+			<source type="control" id-ref="#cisc-6.6"/>
 			<target type="control" id-ref="#IAM-01"> </target>
 		</map>
 		<map uuid="c0baccf0-a438-4d9e-9e81-d4501971d582">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-6.8"/>
+			<source type="control" id-ref="#cisc-6.8"/>
 			<target type="control" id-ref="#IAM-04"> </target>
 		</map>
 		<map uuid="4b90b83e-ca8f-4d94-957c-6c0212e763e6">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-6.8"/>
+			<source type="control" id-ref="#cisc-6.8"/>
 			<target type="control" id-ref="#IAM-05"> </target>
 		</map>
 		<map uuid="4f324b27-3b58-49a4-a25d-779685b1023d">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-6.8"/>
+			<source type="control" id-ref="#cisc-6.8"/>
 			<target type="control" id-ref="#IAM-16"> </target>
 		</map>
 		<map uuid="3f109fc9-68f5-4f70-9290-42ed674d59ce">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-7.1"/>
+			<source type="control" id-ref="#cisc-7.1"/>
 			<target type="control" id-ref="#TVM-01"> </target>
 		</map>
 		<map uuid="6f13ff2a-7e64-492e-99ee-aabbe79b37e1">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-7.1"/>
+			<source type="control" id-ref="#cisc-7.1"/>
 			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="af47907d-4def-4a92-adf8-b97f588d37b9">
 			<relationship>supserset</relationship>
-			<source type="control" id-ref="#cis-7.1"/>
+			<source type="control" id-ref="#cisc-7.1"/>
 			<target type="control" id-ref="#TVM-09"> </target>
 		</map>
 		<map uuid="5352bb00-3207-455e-9972-7c0ed30db637">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-7.2"/>
+			<source type="control" id-ref="#cisc-7.2"/>
 			<target type="control" id-ref="#A&amp;Amp;A-03"> </target>
 		</map>
 		<map uuid="44725d67-6f5a-4ab4-8ea2-eca43418f077">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-7.2"/>
+			<source type="control" id-ref="#cisc-7.2"/>
 			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
 		<map uuid="d4add505-1cd1-441c-b28b-f6afcdc96d3c">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-7.2"/>
+			<source type="control" id-ref="#cisc-7.2"/>
 			<target type="control" id-ref="#TVM-10"> </target>
 		</map>
 		<map uuid="06c281c0-eb00-44a3-8b62-ad36c2644e27">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-7.3"/>
+			<source type="control" id-ref="#cisc-7.3"/>
 			<target type="control" id-ref="#UEM-07"> </target>
 		</map>
 		<map uuid="dbf050b6-cb7f-4d8b-8989-d4dbcd4efe34">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-7.4"/>
+			<source type="control" id-ref="#cisc-7.4"/>
 			<target type="control" id-ref="#UEM-03"> </target>
 		</map>
 		<map uuid="c178e1f7-5581-437d-8505-082495c16f74">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-7.5"/>
+			<source type="control" id-ref="#cisc-7.5"/>
 			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="295ef882-ba37-4889-9a49-f43e7141d115">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-7.6"/>
+			<source type="control" id-ref="#cisc-7.6"/>
 			<target type="control" id-ref="#TVM-07"> </target>
 		</map>
 		<map uuid="1c8344e7-3819-4d3f-a587-aea14c1db0e1">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-7.7"/>
+			<source type="control" id-ref="#cisc-7.7"/>
 			<target type="control" id-ref="#TVM-03"> </target>
 		</map>
 		<map uuid="de1c4e0f-f6a0-4302-b161-1e5bdfd34e04">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-8.1"/>
+			<source type="control" id-ref="#cisc-8.1"/>
 			<target type="control" id-ref="#A&amp;A-01"> </target>
 		</map>
 		<map uuid="56b70c69-e466-4b79-9ad9-971d401f1bc3">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-8.1"/>
+			<source type="control" id-ref="#cisc-8.1"/>
 			<target type="control" id-ref="#LOG-01"> </target>
 		</map>
 		<map uuid="d9b2134c-f84e-459a-9f97-71d224f13462">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-8.1"/>
+			<source type="control" id-ref="#cisc-8.1"/>
 			<target type="control" id-ref="#LOG-07"> </target>
 		</map>
 		<map uuid="84db0645-9b8d-4efe-893d-ffe2cb3867c8">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-8.2"/>
+			<source type="control" id-ref="#cisc-8.2"/>
 			<target type="control" id-ref="#LOG-08"> </target>
 		</map>
 		<map uuid="e91647e9-de63-419e-8b69-8021d073c49c">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-8.4"/>
+			<source type="control" id-ref="#cisc-8.4"/>
 			<target type="control" id-ref="#LOG-06"> </target>
 		</map>
 		<map uuid="24672f5a-38f5-49b2-9427-d6205a703a95">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-8.5"/>
+			<source type="control" id-ref="#cisc-8.5"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="cb7bdf51-7d8d-4575-9080-3d74266a4956">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-8.5"/>
+			<source type="control" id-ref="#cisc-8.5"/>
 			<target type="control" id-ref="#LOG-03"> </target>
 		</map>
 		<map uuid="cd0d9304-d263-4b15-a940-e29ce11a5952">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-8.10"/>
+			<source type="control" id-ref="#cisc-8.10"/>
 			<target type="control" id-ref="#LOG-02"> </target>
 		</map>
 		<map uuid="cb23c6be-2b68-422f-b96a-4649ac767cb7">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-8.11"/>
+			<source type="control" id-ref="#cisc-8.11"/>
 			<target type="control" id-ref="#LOG-05"> </target>
 		</map>
 		<map uuid="637f084d-07f0-4f1c-aefb-352dc60127ad">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-8.11"/>
+			<source type="control" id-ref="#cisc-8.11"/>
 			<target type="control" id-ref="#LOG-13"> </target>
 		</map>
 		<map uuid="ce24c911-24de-4db6-b513-c5b56e43e9e8">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-9.7"/>
+			<source type="control" id-ref="#cisc-9.7"/>
 			<target type="control" id-ref="#TVM-02"> </target>
 		</map>
 		<map uuid="071a7f32-b337-4907-8971-057b6d51dd85">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-10.1"/>
+			<source type="control" id-ref="#cisc-10.1"/>
 			<target type="control" id-ref="#TVM-02"> </target>
 		</map>
 		<map uuid="e7507be2-11d7-4e3c-8c7b-506026eb38ef">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-10.1"/>
+			<source type="control" id-ref="#cisc-10.1"/>
 			<target type="control" id-ref="#UEM-09"> </target>
 		</map>
 		<map uuid="429dec9a-09e9-48d7-a1b9-6e28f88b8a76">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-10.2"/>
+			<source type="control" id-ref="#cisc-10.2"/>
 			<target type="control" id-ref="#TVM-04"> </target>
 		</map>
 		<map uuid="08f4e56c-fe2d-447f-aa5b-287b1554079d">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-12.2"/>
+			<source type="control" id-ref="#cisc-12.2"/>
 			<target type="control" id-ref="#DSP-07"> </target>
 		</map>
 		<map uuid="58d38197-854b-4906-99f9-6a6dace91752">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-12.2"/>
+			<source type="control" id-ref="#cisc-12.2"/>
 			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="957b9cd4-47c5-4f0b-b92e-7e8d1cf7c253">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-12.4"/>
+			<source type="control" id-ref="#cisc-12.4"/>
 			<target type="control" id-ref="#IVS-08"> </target>
 		</map>
 		<map uuid="b2f139c5-382e-4838-ad66-8e2605cbf2b9">
 			<relationship>intersects</relationship>
-			<source type="control" id-ref="#cis-12.5"/>
+			<source type="control" id-ref="#cisc-12.5"/>
 			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="5a5149e7-f522-4871-88a5-5134aeb64d6f">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-12.7"/>
+			<source type="control" id-ref="#cisc-12.7"/>
 			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="5bddbe2f-cd2e-4133-a3c9-b6602876a14a">
 			<relationship>intersects</relationship>
-			<source type="control" id-ref="#cis-12.7"/>
+			<source type="control" id-ref="#cisc-12.7"/>
 			<target type="control" id-ref="#IAM-14"> </target>
 		</map>
 		<map uuid="e4dc90c5-f6e8-4262-9f81-e91f77f85628">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-13.1"/>
+			<source type="control" id-ref="#cisc-13.1"/>
 			<target type="control" id-ref="#LOG-03"> </target>
 		</map>
 		<map uuid="8a792030-f33b-4ae6-86a4-5887a8da25ea">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.1"/>
+			<source type="control" id-ref="#cisc-13.1"/>
 			<target type="control" id-ref="#SEF-01"> </target>
 		</map>
 		<map uuid="8898cb4d-bd5a-4579-976f-469801b77e44">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.3"/>
+			<source type="control" id-ref="#cisc-13.3"/>
 			<target type="control" id-ref="#IVS-09"> </target>
 		</map>
 		<map uuid="9e50aa9e-ef48-4125-94b7-f8a5af255e5c">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.5"/>
+			<source type="control" id-ref="#cisc-13.5"/>
 			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="e46c826a-47ca-409d-aeea-67c857d48282">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.6"/>
+			<source type="control" id-ref="#cisc-13.6"/>
 			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="7c7708cb-6fd7-4e04-a897-5095745768f7">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.8"/>
+			<source type="control" id-ref="#cisc-13.8"/>
 			<target type="control" id-ref="#IVS-09"> </target>
 		</map>
 		<map uuid="0d77eccd-3df7-4c41-9299-25b58a73491c">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-13.9"/>
+			<source type="control" id-ref="#cisc-13.9"/>
 			<target type="control" id-ref="#IVS-03"> </target>
 		</map>
 		<map uuid="b6bfa101-06bf-4169-8711-114d67f93cbf">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-14.1"/>
+			<source type="control" id-ref="#cisc-14.1"/>
 			<target type="control" id-ref="#GRC-05"> </target>
 		</map>
 		<map uuid="8bbac20f-5444-4664-ade0-2150798f1327">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-14.1"/>
+			<source type="control" id-ref="#cisc-14.1"/>
 			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="4e546bea-9675-4c6a-8ce0-94d11fb0a4bb">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-14.1"/>
+			<source type="control" id-ref="#cisc-14.1"/>
 			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="531ace4b-35c3-4d8c-b805-c224ada6a83d">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.2"/>
+			<source type="control" id-ref="#cisc-14.2"/>
 			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="a0074c66-480c-4cb7-badc-0c9fd5f785a2">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.3"/>
+			<source type="control" id-ref="#cisc-14.3"/>
 			<target type="control" id-ref="#GRC-05"> </target>
 		</map>
 		<map uuid="29652793-13aa-4b30-a9d9-585279a0c115">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.3"/>
+			<source type="control" id-ref="#cisc-14.3"/>
 			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="e8a8e264-1044-4e76-97c8-42688bccba09">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.4"/>
+			<source type="control" id-ref="#cisc-14.4"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="57b39cd8-2494-4336-88af-ca19b8f1d5e8">
 			<relationship>intersects</relationship>
-			<source type="control" id-ref="#cis-14.4"/>
+			<source type="control" id-ref="#cisc-14.4"/>
 			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="90f58a67-9e97-4c54-add0-21ece8adc949">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-14.4"/>
+			<source type="control" id-ref="#cisc-14.4"/>
 			<target type="control" id-ref="#HRS-03"> </target>
 		</map>
 		<map uuid="7ac6b858-3106-495d-8bf4-23902dcfcf71">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-14.4"/>
+			<source type="control" id-ref="#cisc-14.4"/>
 			<target type="control" id-ref="#HRS-12"> </target>
 		</map>
 		<map uuid="42cc1ba2-362d-43cc-b441-7bbad551a673">
 			<relationship>intersects</relationship>
-			<source type="control" id-ref="#cis-14.5"/>
+			<source type="control" id-ref="#cisc-14.5"/>
 			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="a6f9056c-ce90-4145-bd86-143ea34e3671">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.5"/>
+			<source type="control" id-ref="#cisc-14.5"/>
 			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="c0c778df-a55d-48b1-b1a0-5ec7b4dfb90f">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.6"/>
+			<source type="control" id-ref="#cisc-14.6"/>
 			<target type="control" id-ref="#HRS-11"> </target>
 		</map>
 		<map uuid="ff0525a2-b9c5-4a2e-a2ac-bacd99a8aa67">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.7"/>
+			<source type="control" id-ref="#cisc-14.7"/>
 			<target type="control" id-ref="#DSP-17"> </target>
 		</map>
 		<map uuid="7cdb93c4-e295-476c-8850-b46941b6ea74">
 			<relationship>intersects</relationship>
-			<source type="control" id-ref="#cis-14.8"/>
+			<source type="control" id-ref="#cisc-14.8"/>
 			<target type="control" id-ref="#GRC-01"> </target>
 		</map>
 		<map uuid="1a7b7c1e-b876-41a9-8479-1bf50ceae9f9">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.8"/>
+			<source type="control" id-ref="#cisc-14.8"/>
 			<target type="control" id-ref="#HRS-04"> </target>
 		</map>
 		<map uuid="fa93b58d-400e-43d3-bf26-ff57d5a75de2">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-14.9"/>
+			<source type="control" id-ref="#cisc-14.9"/>
 			<target type="control" id-ref="#HRS-09"> </target>
 		</map>
 		<map uuid="832316fd-c936-4149-b52a-29cd12e180c5">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-14.9"/>
+			<source type="control" id-ref="#cisc-14.9"/>
 			<target type="control" id-ref="#HRS-12"> </target>
 		</map>
 		<map uuid="f0aa30e3-c629-4bed-b1d0-379a45217d7b">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-15.1"/>
+			<source type="control" id-ref="#cisc-15.1"/>
 			<target type="control" id-ref="#STA-07"> </target>
 		</map>
 		<map uuid="24c77842-ad8b-484b-9eba-64be619a8b51">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-15.3"/>
+			<source type="control" id-ref="#cisc-15.3"/>
 			<target type="control" id-ref="#GRC-02"> </target>
 		</map>
 		<map uuid="d6a4b5b7-bda3-47dd-9eb9-f3b8cc2b3050">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-15.3"/>
+			<source type="control" id-ref="#cisc-15.3"/>
 			<target type="control" id-ref="#STA-08"> </target>
 		</map>
 		<map uuid="0d2ce502-9913-492c-9dbc-0b84e2a86694">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-15.4"/>
+			<source type="control" id-ref="#cisc-15.4"/>
 			<target type="control" id-ref="#STA-09"> </target>
 		</map>
 		<map uuid="a31ec15b-5b56-4c01-a658-6626655ebb69">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-15.4"/>
+			<source type="control" id-ref="#cisc-15.4"/>
 			<target type="control" id-ref="#STA-10"> </target>
 		</map>
 		<map uuid="0998c607-88bf-4d55-bbe8-9707b6e0d0ae">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-15.4"/>
+			<source type="control" id-ref="#cisc-15.4"/>
 			<target type="control" id-ref="#UEM-14"> </target>
 		</map>
 		<map uuid="40d9de65-15b4-42dc-8db6-3360e76dee22">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-15.5"/>
+			<source type="control" id-ref="#cisc-15.5"/>
 			<target type="control" id-ref="#STA-12"> </target>
 		</map>
 		<map uuid="9152d107-c4cb-4cf4-87f3-d1a15decc73a">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-15.5"/>
+			<source type="control" id-ref="#cisc-15.5"/>
 			<target type="control" id-ref="#STA-13"> </target>
 		</map>
 		<map uuid="d36fe370-5d14-4983-8123-109eeac3b29d">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-15.6"/>
+			<source type="control" id-ref="#cisc-15.6"/>
 			<target type="control" id-ref="#STA-14"> </target>
 		</map>
 		<map uuid="b64583a0-da87-4636-a8b8-6d2b7d7ac319">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-16.1"/>
+			<source type="control" id-ref="#cisc-16.1"/>
 			<target type="control" id-ref="#AIS-01"> </target>
 		</map>
 		<map uuid="f45bd4a4-1740-402c-bfdb-ec84f88df42f">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-16.1"/>
+			<source type="control" id-ref="#cisc-16.1"/>
 			<target type="control" id-ref="#AIS-04"> </target>
 		</map>
 		<map uuid="b0f3dc8f-2a62-4f2f-97f7-f58d64fe23ea">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-16.2"/>
+			<source type="control" id-ref="#cisc-16.2"/>
 			<target type="control" id-ref="#AIS-03"> </target>
 		</map>
 		<map uuid="067f2fc0-1df3-4cb4-9bc4-2387f720aef4">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-16.2"/>
+			<source type="control" id-ref="#cisc-16.2"/>
 			<target type="control" id-ref="#AIS-07"> </target>
 		</map>
 		<map uuid="ef8add2b-e0f2-4ba4-85fa-0f8c9d1c1c29">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-16.4"/>
+			<source type="control" id-ref="#cisc-16.4"/>
 			<target type="control" id-ref="#GRC-02"> </target>
 		</map>
 		<map uuid="fe022e31-b394-479a-9f03-a21261a0493d">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-16.6"/>
+			<source type="control" id-ref="#cisc-16.6"/>
 			<target type="control" id-ref="#AIS-07"> </target>
 		</map>
 		<map uuid="cb2e3386-c8f0-4d70-aaec-3052ebe358f1">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-16.6"/>
+			<source type="control" id-ref="#cisc-16.6"/>
 			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
 		<map uuid="bda3184b-060b-4764-b9a1-0bb8e59fcca8">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-16.7"/>
+			<source type="control" id-ref="#cisc-16.7"/>
 			<target type="control" id-ref="#AIS-02"> </target>
 		</map>
 		<map uuid="c0cde3e1-aef6-4d77-a02a-8cc983d7e5ec">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-16.8"/>
+			<source type="control" id-ref="#cisc-16.8"/>
 			<target type="control" id-ref="#IVS-05"> </target>
 		</map>
 		<map uuid="71f1432c-18ad-4f85-a750-53d4e4a9dc12">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-16.10"/>
+			<source type="control" id-ref="#cisc-16.10"/>
 			<target type="control" id-ref="#DSP-07"> </target>
 		</map>
 		<map uuid="9bf8c233-d453-4013-9493-13b706c73da9">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-16.12"/>
+			<source type="control" id-ref="#cisc-16.12"/>
 			<target type="control" id-ref="#AIS-05"> </target>
 		</map>
 		<map uuid="bd9f9079-083e-47bc-b2ec-a8824737c489">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-16.13"/>
+			<source type="control" id-ref="#cisc-16.13"/>
 			<target type="control" id-ref="#AIS-05"> </target>
 		</map>
 		<map uuid="1c7e970c-3807-4a29-aa72-74e1b1b6358a">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-17.1"/>
+			<source type="control" id-ref="#cisc-17.1"/>
 			<target type="control" id-ref="#BCR-01"> </target>
 		</map>
 		<map uuid="71c0bf75-0466-458b-a842-68af5f3cdf1b">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-17.1"/>
+			<source type="control" id-ref="#cisc-17.1"/>
 			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="0fe69621-ddcd-4f54-95f2-5a3a329eec9e">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-17.2"/>
+			<source type="control" id-ref="#cisc-17.2"/>
 			<target type="control" id-ref="#SEF-08"> </target>
 		</map>
 		<map uuid="5a13e251-3a33-4c27-a26a-9d0b9917f60e">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-17.2"/>
+			<source type="control" id-ref="#cisc-17.2"/>
 			<target type="control" id-ref="#SEF-07"> </target>
 		</map>
 		<map uuid="5600b5b0-a870-4ad9-a673-eef11c51deca">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-17.4"/>
+			<source type="control" id-ref="#cisc-17.4"/>
 			<target type="control" id-ref="#SEF-01"> </target>
 		</map>
 		<map uuid="6807754f-2032-4ad5-8a85-b9d63c26402f">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-17.4"/>
+			<source type="control" id-ref="#cisc-17.4"/>
 			<target type="control" id-ref="#SEF-02"> </target>
 		</map>
 		<map uuid="c89042bb-922d-42b9-be2c-17588e60be9a">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-17.4"/>
+			<source type="control" id-ref="#cisc-17.4"/>
 			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="4d084a7c-e27a-4e8d-a00b-f5afeb9f5d9e">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-17.4"/>
+			<source type="control" id-ref="#cisc-17.4"/>
 			<target type="control" id-ref="#SEF-06"> </target>
 		</map>
 		<map uuid="1cb4a029-07ee-4817-ab32-289db9c7ba2e">
 			<relationship>superset-of</relationship>
-			<source type="control" id-ref="#cis-17.4"/>
+			<source type="control" id-ref="#cisc-17.4"/>
 			<target type="control" id-ref="#GRC-03"> </target>
 		</map>
 		<map uuid="0c54052b-fe01-44aa-aef5-a30fe489e838">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-17.5"/>
+			<source type="control" id-ref="#cisc-17.5"/>
 			<target type="control" id-ref="#SEF-03"> </target>
 		</map>
 		<map uuid="cb8d447b-c97a-45a3-8cd4-a61f4466a35d">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-17.7"/>
+			<source type="control" id-ref="#cisc-17.7"/>
 			<target type="control" id-ref="#SEF-04"> </target>
 		</map>
 		<map uuid="a1713855-8283-4f2d-87e8-cf77de583483">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-17.9"/>
+			<source type="control" id-ref="#cisc-17.9"/>
 			<target type="control" id-ref="#SEF-05"> </target>
 		</map>
 		<map uuid="838991d0-b2f2-4c9e-b370-01ff63c85061">
 			<relationship>equivalent-to</relationship>
-			<source type="control" id-ref="#cis-18.1"/>
+			<source type="control" id-ref="#cisc-18.1"/>
 			<target type="control" id-ref="#TVM-06"> </target>
 		</map>
 		<map uuid="19299403-6122-4d97-b5f1-907137699c6b">
 			<relationship>subset-of</relationship>
-			<source type="control" id-ref="#cis-18.3"/>
+			<source type="control" id-ref="#cisc-18.3"/>
 			<target type="control" id-ref="#TVM-08"> </target>
 		</map>
 	</mapping>

--- a/cis-controls-v8_OSCAL-1.0.xml
+++ b/cis-controls-v8_OSCAL-1.0.xml
@@ -5,135 +5,135 @@
  xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.4/xml/schema/oscal_catalog_schema.xsd"
  uuid="e95fb23c-57d2-495f-8ab5-2c6b3152bcee">
  <metadata>
- <title>CIS Controls</title>
- <last-modified>2022-01-19T16:00:34.033789-05:00</last-modified>
- <version>8.0</version>
- <oscal-version>1.0.0</oscal-version>
- <prop name="keywords" value="contol, assessment"/>
- <link rel="alternate"
- media-type="text/html"
- href="https://controls-assessment-specification.readthedocs.io/en/stable/index.html"/>
+  <title>CIS Controls</title>
+  <last-modified>2022-01-19T16:00:34.033789-05:00</last-modified>
+  <version>8.0</version>
+  <oscal-version>1.0.0</oscal-version>
+  <prop name="keywords" value="contol, assessment"/>
+  <link rel="alternate" media-type="text/html"
+   href="https://controls-assessment-specification.readthedocs.io/en/stable/index.html"/>
  </metadata>
  <control id="cisc-1">
- <title>Inventory and Control of Enterprise Assets</title>
- <prop name="label" value="CIS Control 1"/>
- <prop name="sort-id" value="cisc-01"/>
- <part name="statement" id="cisc-1_stmt">
- <p>Actively manage (inventory, track, and correct) all enterprise assets (end-user devices, including portable and mobile; network devices; non-computing/Internet of Things (IoT) devices; and servers) connected to the infrastructure, physically, virtually, remotely, and those within cloud environments, to accurately know the totality of assets that need to be monitored and protected within the enterprise. This will also support identifying unauthorized and unmanaged assets to remove or remediate.</p>
- </part>
- <part name="guidance" id="cisc-1_gdn">
- <p>Enterprises cannot defend what they do not know they have. Managed control of all enterprise assets also plays a critical role in security monitoring, incident response, system backup, and recovery. Enterprises should know what data is critical to them, and proper asset management will help identify those enterprise assets that hold or manage this critical data, so appropriate security controls can be applied.</p>
- <p>External attackers are continuously scanning the internet address space of target enterprises, premise-based or in the cloud, identifying possibly unprotected assets attached to enterprises’ networks. Attackers can take advantage of new assets that are installed, yet not securely configured and patched. Internally, unidentified assets can also have weak security configurations that can make them vulnerable to web or email-based malware; and adversaries can leverage weak security configurations for traversing the network, once they are inside.</p>
- <p>Additional assets that connect to the enterprise’s network (e.g., demonstration systems, temporary test systems, guest networks, etc.) should be identified and/or isolated, in order to prevent adversarial access from affecting the security of enterprise operations.</p>
- <p>Large, complex, dynamic enterprises understandably struggle with the challenge of managing intricate, fast-changing environments. However, attackers have shown the ability, patience, and willingness to “inventory and control” our enterprise assets at very large scale in order to support their opportunities.</p>
- <p>Another challenge is that portable end-user devices will periodically join a network and then disappear, making the inventory of currently available assets very dynamic. Likewise, cloud environments and virtual machines can be difficult to track in asset inventories when they are shut down or paused. Another benefit of complete enterprise asset management is supporting incident response. Both when investigating the origination of network traffic from an asset on the network, and to be able to identify all potentially vulnerable, or impacted, assets of similar type or location during an incident.</p>
- </part>
+  <title>Inventory and Control of Enterprise Assets</title>
+  <prop name="label" value="CIS Control 1"/>
+  <prop name="sort-id" value="cisc-01"/>
+  <part name="statement" id="cisc-1_stmt">
+   <p>Actively manage (inventory, track, and correct) all enterprise assets (end-user devices,
+    including portable and mobile; network devices; non-computing/Internet of Things (IoT) devices;
+    and servers) connected to the infrastructure, physically, virtually, remotely, and those within
+    cloud environments, to accurately know the totality of assets that need to be monitored and
+    protected within the enterprise. This will also support identifying unauthorized and unmanaged
+    assets to remove or remediate.</p>
+  </part>
+  <part name="guidance" id="cisc-1_gdn">
+   <p>Enterprises cannot defend what they do not know they have. Managed control of all enterprise
+    assets also plays a critical role in security monitoring, incident response, system backup, and
+    recovery. Enterprises should know what data is critical to them, and proper asset management
+    will help identify those enterprise assets that hold or manage this critical data, so
+    appropriate security controls can be applied.</p>
+   <p>External attackers are continuously scanning the internet address space of target enterprises,
+    premise-based or in the cloud, identifying possibly unprotected assets attached to enterprises’
+    networks. Attackers can take advantage of new assets that are installed, yet not securely
+    configured and patched. Internally, unidentified assets can also have weak security
+    configurations that can make them vulnerable to web or email-based malware; and adversaries can
+    leverage weak security configurations for traversing the network, once they are inside.</p>
+   <p>Additional assets that connect to the enterprise’s network (e.g., demonstration systems,
+    temporary test systems, guest networks, etc.) should be identified and/or isolated, in order to
+    prevent adversarial access from affecting the security of enterprise operations.</p>
+   <p>Large, complex, dynamic enterprises understandably struggle with the challenge of managing
+    intricate, fast-changing environments. However, attackers have shown the ability, patience, and
+    willingness to “inventory and control” our enterprise assets at very large scale in order to
+    support their opportunities.</p>
+   <p>Another challenge is that portable end-user devices will periodically join a network and then
+    disappear, making the inventory of currently available assets very dynamic. Likewise, cloud
+    environments and virtual machines can be difficult to track in asset inventories when they are
+    shut down or paused. Another benefit of complete enterprise asset management is supporting
+    incident response. Both when investigating the origination of network traffic from an asset on
+    the network, and to be able to identify all potentially vulnerable, or impacted, assets of
+    similar type or location during an incident.</p>
+  </part>
   <control id="cisc-1.1">
    <title>Establish and Maintain Detailed Enterprise Asset Inventory</title>
    <prop name="label" value="CIS Safeguard 1.1"/>
    <prop name="sort-id" value="cisc-01.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="asset-type"
-   value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="security-function"
-   value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-1.1_stmt">
-   <p>Establish and maintain an accurate, detailed, and up-to-date inventory of all enterprise assets with the potential to store or process data, to include: end-user devices (including portable and mobile), network devices, non-computing/IoT devices, and servers. Ensure the inventory records the network address (if static), hardware address, machine name, data asset owner, department for each asset, and whether the asset has been approved to connect to the network. For mobile end-user devices, MDM type tools can support this process, where appropriate. This inventory includes assets connected to the infrastructure physically, virtually, remotely, and those within cloud environments. Additionally, it includes assets that are regularly connected to the enterprise’s network infrastructure, even if they are not under control of the enterprise. Review and update the inventory of all enterprise assets bi-annually, or more frequently.</p>
+    <p>Establish and maintain an accurate, detailed, and up-to-date inventory of all enterprise
+     assets with the potential to store or process data, to include: end-user devices (including
+     portable and mobile), network devices, non-computing/IoT devices, and servers. Ensure the
+     inventory records the network address (if static), hardware address, machine name, data asset
+     owner, department for each asset, and whether the asset has been approved to connect to the
+     network. For mobile end-user devices, MDM type tools can support this process, where
+     appropriate. This inventory includes assets connected to the infrastructure physically,
+     virtually, remotely, and those within cloud environments. Additionally, it includes assets that
+     are regularly connected to the enterprise’s network infrastructure, even if they are not under
+     control of the enterprise. Review and update the inventory of all enterprise assets
+     bi-annually, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-1.2">
    <title>Address Unauthorized Assets</title>
    <prop name="label" value="CIS Safeguard 1.2"/>
    <prop name="sort-id" value="cisc-01.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="asset-type"
-   value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="security-function"
-   value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-1.2_stmt">
-   <p>Ensure that a process exists to address unauthorized assets on a weekly basis. The enterprise may choose to remove the asset from the network, deny the asset from connecting remotely to the network, or quarantine the asset.</p>
+    <p>Ensure that a process exists to address unauthorized assets on a weekly basis. The enterprise
+     may choose to remove the asset from the network, deny the asset from connecting remotely to the
+     network, or quarantine the asset.</p>
    </part>
   </control>
   <control id="cisc-1.3">
    <title>Utilize an Active Discovery Tool</title>
    <prop name="label" value="CIS Safeguard 1.3"/>
    <prop name="sort-id" value="cisc-01.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="asset-type"
-   value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="security-function"
-   value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-1.3_stmt">
-   <p>Utilize an active discovery tool to identify assets connected to the enterprise’s network. Configure the active discovery tool to execute daily, or more frequently.</p>
+    <p>Utilize an active discovery tool to identify assets connected to the enterprise’s network.
+     Configure the active discovery tool to execute daily, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-1.4">
-   <title>Use Dynamic Host Configuration Protocol (DHCP) Logging to Update Enterprise Asset Inventory</title>
+   <title>Use Dynamic Host Configuration Protocol (DHCP) Logging to Update Enterprise Asset
+    Inventory</title>
    <prop name="label" value="CIS Safeguard 1.4"/>
    <prop name="sort-id" value="cisc-01.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="asset-type"
-   value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="security-function"
-   value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-1.4_stmt">
-   <p>Use DHCP logging on all DHCP servers or Internet Protocol (IP) address management tools to update the enterprise’s asset inventory. Review and use logs to update the enterprise’s asset inventory weekly, or more frequently.</p>
+    <p>Use DHCP logging on all DHCP servers or Internet Protocol (IP) address management tools to
+     update the enterprise’s asset inventory. Review and use logs to update the enterprise’s asset
+     inventory weekly, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-1.5">
    <title>Use a Passive Asset Discovery Tool</title>
    <prop name="label" value="CIS Safeguard 1.5"/>
    <prop name="sort-id" value="cisc-01.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="asset-type"
-   value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="security-function"
-   value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-   value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.2"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-1.5_stmt">
-   <p>Use a passive discovery tool to identify assets connected to the enterprise’s network. Review and use scans to update the enterprise’s asset inventory at least weekly, or more frequently.</p>
+    <p>Use a passive discovery tool to identify assets connected to the enterprise’s network. Review
+     and use scans to update the enterprise’s asset inventory at least weekly, or more
+     frequently.</p>
    </part>
   </control>
  </control>
@@ -142,171 +142,147 @@
   <prop name="label" value="CIS Control 2"/>
   <prop name="sort-id" value="cisc-02"/>
   <part name="statement" id="cisc-2_stmt">
-   <p>Actively manage (inventory, track, and correct) all software (operating systems and applications) on the network so that only authorized software is installed and can execute, and that unauthorized and unmanaged software is found and prevented from installation or execution.</p>
+   <p>Actively manage (inventory, track, and correct) all software (operating systems and
+    applications) on the network so that only authorized software is installed and can execute, and
+    that unauthorized and unmanaged software is found and prevented from installation or
+    execution.</p>
   </part>
   <part name="guidance" id="cisc-2_gdn">
-   <p>A complete software inventory is a critical foundation for preventing attacks. Attackers continuously scan target enterprises looking for vulnerable versions of software that can be remotely exploited. For example, if a user opens a malicious website or attachment with a vulnerable browser, an attacker can often install backdoor programs and bots that give the attacker long-term control of the system. Attackers can also use this access to move laterally through the network. One of the key defenses against these attacks is updating and patching software. However, without a complete inventory of software assets, an enterprise cannot determine if they have vulnerable software, or if there are potential licensing violations.</p>
-   <p>Even if a patch is not yet available, a complete software inventory list allows an enterprise to guard against known attacks until the patch is released. Some sophisticated attackers use “zero-day exploits”, which take advantage of previously unknown vulnerabilities that have yet to have a patch released by the software vendor. Depending on the severity of the exploit, an enterprise can implement temporary mitigation measures to guard against attacks until the patch is released.</p>
-   <p>Management of software assets is also important to identify unnecessary security risks. An enterprise should review their software inventory to identify any enterprise assets running software that is not needed for business purposes. For example, an enterprise asset may come installed with default software that creates a potential security risk and provides no benefit to the enterprise. It is critical to inventory, understand, assess, and manage all software connected to an enterprise’s infrastructure.</p>
+   <p>A complete software inventory is a critical foundation for preventing attacks. Attackers
+    continuously scan target enterprises looking for vulnerable versions of software that can be
+    remotely exploited. For example, if a user opens a malicious website or attachment with a
+    vulnerable browser, an attacker can often install backdoor programs and bots that give the
+    attacker long-term control of the system. Attackers can also use this access to move laterally
+    through the network. One of the key defenses against these attacks is updating and patching
+    software. However, without a complete inventory of software assets, an enterprise cannot
+    determine if they have vulnerable software, or if there are potential licensing violations.</p>
+   <p>Even if a patch is not yet available, a complete software inventory list allows an enterprise
+    to guard against known attacks until the patch is released. Some sophisticated attackers use
+    “zero-day exploits”, which take advantage of previously unknown vulnerabilities that have yet to
+    have a patch released by the software vendor. Depending on the severity of the exploit, an
+    enterprise can implement temporary mitigation measures to guard against attacks until the patch
+    is released.</p>
+   <p>Management of software assets is also important to identify unnecessary security risks. An
+    enterprise should review their software inventory to identify any enterprise assets running
+    software that is not needed for business purposes. For example, an enterprise asset may come
+    installed with default software that creates a potential security risk and provides no benefit
+    to the enterprise. It is critical to inventory, understand, assess, and manage all software
+    connected to an enterprise’s infrastructure.</p>
   </part>
   <control id="cisc-2.1">
    <title>Establish and Maintain a Software Inventory</title>
    <prop name="label" value="CIS Safeguard 2.1"/>
    <prop name="sort-id" value="cisc-02.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-2.1_stmt">
-    <p>Establish and maintain a detailed inventory of all licensed software installed on enterprise assets. The software inventory must document the title, publisher, initial install/use date, and business purpose for each entry; where appropriate, include the Uniform Resource Locator (URL), app store(s), version(s), deployment mechanism, and decommission date. Review and update the software inventory bi-annually, or more frequently.</p>
+    <p>Establish and maintain a detailed inventory of all licensed software installed on enterprise
+     assets. The software inventory must document the title, publisher, initial install/use date,
+     and business purpose for each entry; where appropriate, include the Uniform Resource Locator
+     (URL), app store(s), version(s), deployment mechanism, and decommission date. Review and update
+     the software inventory bi-annually, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-2.2">
    <title>Ensure Authorized Software is Currently Supported</title>
    <prop name="label" value="CIS Safeguard 2.2"/>
    <prop name="sort-id" value="cisc-02.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-1.2_stmt">
-    <p>Ensure that only currently supported software is designated as authorized in the software inventory for enterprise assets. If software is unsupported yet necessary for the fulfillment of the enterprise’s mission, document an exception detailing mitigating controls and residual risk acceptance. For any unsupported software without an exception documentation, designate as unauthorized. Review the software list to verify software support at least monthly, or more frequently.</p>
+    <p>Ensure that only currently supported software is designated as authorized in the software
+     inventory for enterprise assets. If software is unsupported yet necessary for the fulfillment
+     of the enterprise’s mission, document an exception detailing mitigating controls and residual
+     risk acceptance. For any unsupported software without an exception documentation, designate as
+     unauthorized. Review the software list to verify software support at least monthly, or more
+     frequently.</p>
    </part>
   </control>
   <control id="cisc-2.3">
    <title>Address Unauthorized Software</title>
    <prop name="label" value="CIS Safeguard 2.3"/>
    <prop name="sort-id" value="cisc-02.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-2.3_stmt">
-    <p>Ensure that unauthorized software is either removed from use on enterprise assets or receives a documented exception. Review monthly, or more frequently.</p>
+    <p>Ensure that unauthorized software is either removed from use on enterprise assets or receives
+     a documented exception. Review monthly, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-2.4">
    <title>Utilize Automated Software Inventory Tools</title>
    <prop name="label" value="CIS Safeguard 2.4"/>
    <prop name="sort-id" value="cisc-02.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.3"/>
    <part name="statement" id="cisc-2.4_stmt">
-    <p>Utilize software inventory tools, when possible, throughout the enterprise to automate the discovery and documentation of installed software.</p>
+    <p>Utilize software inventory tools, when possible, throughout the enterprise to automate the
+     discovery and documentation of installed software.</p>
    </part>
   </control>
   <control id="cisc-2.5">
    <title>Allowlist Authorized Software</title>
    <prop name="label" value="CIS Safeguard 2.5"/>
    <prop name="sort-id" value="cisc-02.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-2.3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-2.5_stmt">
-    <p>Use technical controls, such as application allowlisting, to ensure that only authorized software can execute or be accessed. Reassess bi-annually, or more frequently.</p>
+    <p>Use technical controls, such as application allowlisting, to ensure that only authorized
+     software can execute or be accessed. Reassess bi-annually, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-2.6">
    <title>Allowlist Authorized Libraries</title>
    <prop name="label" value="CIS Safeguard 2.6"/>
    <prop name="sort-id" value="cisc-02.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-2.5"/>
    <link rel="dependency" href="cisc-4.2"/>
    <part name="statement" id="cisc-2.6_stmt">
-    <p>Use technical controls to ensure that only authorized software libraries, such as specific .dll, .ocx, .so, etc. files, are allowed to load into a system process. Block unauthorized libraries from loading into a system process. Reassess bi-annually, or more frequently.</p>
+    <p>Use technical controls to ensure that only authorized software libraries, such as specific
+     .dll, .ocx, .so, etc. files, are allowed to load into a system process. Block unauthorized
+     libraries from loading into a system process. Reassess bi-annually, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-2.7">
    <title>Allowlist Authorized Scripts</title>
    <prop name="label" value="CIS Safeguard 2.7"/>
    <prop name="sort-id" value="cisc-02.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-2.7_stmt">
-    <p>Use technical controls, such as digital signatures and version control, to ensure that only authorized scripts, such as specific .ps1, .py, etc. files, are allowed to execute. Block unauthorized scripts from executing. Reassess bi-annually, or more frequently.</p>
+    <p>Use technical controls, such as digital signatures and version control, to ensure that only
+     authorized scripts, such as specific .ps1, .py, etc. files, are allowed to execute. Block
+     unauthorized scripts from executing. Reassess bi-annually, or more frequently.</p>
    </part>
   </control>
  </control>
@@ -315,223 +291,173 @@
   <prop name="label" value="CIS Control 3"/>
   <prop name="sort-id" value="cisc-03"/>
   <part name="statement" id="cisc-3_stmt">
-   <p>Develop processes and technical controls to identify, classify, securely handle, retain, and dispose of data.</p>
+   <p>Develop processes and technical controls to identify, classify, securely handle, retain, and
+    dispose of data.</p>
   </part>
   <part name="guidance" id="cisc-3_gdn">
-   <p>Data is no longer only contained within an enterprise’s border, it is in the cloud, on portable end-user devices where users work from home, and is often shared with partners or online services who might have it anywhere in the world. In addition to sensitive data an enterprise holds related to finances, intellectual property, and customer data, there also might be numerous international regulations for protection of personal data. Data privacy has become increasingly important, and enterprises are learning that privacy is about the appropriate use and management of data, not just encryption. Data must be appropriately managed through its entire lifecycle. These privacy rules can be complicated for multi-national enterprises, of any size, however there are fundamentals that can apply to all.</p>
-   <p>Once attackers have penetrated an enterprise’s infrastructure, one of their first tasks is to find and exfiltrate data. Enterprises might not be aware that sensitive data is leaving their environment because they are not monitoring data outflows.</p>
-   <p>While many attacks occur on the network, others involve physical theft of portable end-user devices, attacks on service providers or other partners holding sensitive data. Other sensitive enterprise assets may also include non-computing devices that provide management and control of physical systems, such as Supervisory Control and Data Acquisition (SCADA) systems.</p>
-   <p>The enterprise’s loss of control over protected or sensitive data is a serious and often reportable business impact. While some data is compromised or lost as a result of theft or espionage, the vast majority are a result of poorly understood data management rules, and user error. The adoption of data encryption, both in transit and at rest, can provide mitigation against data compromise, and more importantly, is a regulatory requirement for most controlled data.</p>  
+   <p>Data is no longer only contained within an enterprise’s border, it is in the cloud, on
+    portable end-user devices where users work from home, and is often shared with partners or
+    online services who might have it anywhere in the world. In addition to sensitive data an
+    enterprise holds related to finances, intellectual property, and customer data, there also might
+    be numerous international regulations for protection of personal data. Data privacy has become
+    increasingly important, and enterprises are learning that privacy is about the appropriate use
+    and management of data, not just encryption. Data must be appropriately managed through its
+    entire lifecycle. These privacy rules can be complicated for multi-national enterprises, of any
+    size, however there are fundamentals that can apply to all.</p>
+   <p>Once attackers have penetrated an enterprise’s infrastructure, one of their first tasks is to
+    find and exfiltrate data. Enterprises might not be aware that sensitive data is leaving their
+    environment because they are not monitoring data outflows.</p>
+   <p>While many attacks occur on the network, others involve physical theft of portable end-user
+    devices, attacks on service providers or other partners holding sensitive data. Other sensitive
+    enterprise assets may also include non-computing devices that provide management and control of
+    physical systems, such as Supervisory Control and Data Acquisition (SCADA) systems.</p>
+   <p>The enterprise’s loss of control over protected or sensitive data is a serious and often
+    reportable business impact. While some data is compromised or lost as a result of theft or
+    espionage, the vast majority are a result of poorly understood data management rules, and user
+    error. The adoption of data encryption, both in transit and at rest, can provide mitigation
+    against data compromise, and more importantly, is a regulatory requirement for most controlled
+    data.</p>
   </part>
   <control id="cisc-3.1">
    <title>Establish and Maintain a Data Management Process</title>
    <prop name="label" value="CIS Safeguard 3.1"/>
    <prop name="sort-id" value="cisc-03.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-3.1_stmt">
-    <p>Establish and maintain a data management process. In the process, address data sensitivity, data owner, handling of data, data retention limits, and disposal requirements, based on sensitivity and retention standards for the enterprise. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a data management process. In the process, address data sensitivity,
+     data owner, handling of data, data retention limits, and disposal requirements, based on
+     sensitivity and retention standards for the enterprise. Review and update documentation
+     annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-3.2">
    <title>Establish and Maintain a Data Inventory</title>
    <prop name="label" value="CIS Safeguard 3.2"/>
    <prop name="sort-id" value="cisc-03.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-3.2_stmt">
-    <p>Establish and maintain a data inventory, based on the enterprise’s data management process. Inventory sensitive data, at a minimum. Review and update inventory annually, at a minimum, with a priority on sensitive data.</p>
+    <p>Establish and maintain a data inventory, based on the enterprise’s data management process.
+     Inventory sensitive data, at a minimum. Review and update inventory annually, at a minimum,
+     with a priority on sensitive data.</p>
    </part>
   </control>
   <control id="cisc-3.3">
    <title>Configure Data Access Control Lists</title>
    <prop name="label" value="CIS Safeguard 3.3"/>
    <prop name="sort-id" value="cisc-03.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.2"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-3.3_stmt">
-    <p>Configure data access control lists based on a user’s need to know. Apply data access control lists, also known as access permissions, to local and remote file systems, databases, and applications.</p>
+    <p>Configure data access control lists based on a user’s need to know. Apply data access control
+     lists, also known as access permissions, to local and remote file systems, databases, and
+     applications.</p>
    </part>
   </control>
   <control id="cisc-3.4">
    <title>Enforce Data Retention</title>
    <prop name="label" value="CIS Safeguard 3.4"/>
    <prop name="sort-id" value="cisc-03.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.1"/>
    <link rel="dependency" href="cisc-3.2"/>
    <part name="statement" id="cisc-3.4_stmt">
-    <p>Retain data according to the enterprise’s data management process. Data retention must include both minimum and maximum timelines.</p>
+    <p>Retain data according to the enterprise’s data management process. Data retention must
+     include both minimum and maximum timelines.</p>
    </part>
   </control>
   <control id="cisc-3.5">
    <title>Securely Dispose of Data</title>
    <prop name="label" value="CIS Safeguard 3.5"/>
    <prop name="sort-id" value="cisc-03.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.1"/>
    <link rel="dependency" href="cisc-3.2"/>
    <part name="statement" id="cisc-3.5_stmt">
-    <p>Securely dispose of data as outlined in the enterprise’s data management process. Ensure the disposal process and method are commensurate with the data sensitivity.</p>
+    <p>Securely dispose of data as outlined in the enterprise’s data management process. Ensure the
+     disposal process and method are commensurate with the data sensitivity.</p>
    </part>
   </control>
   <control id="cisc-3.6">
    <title>Encrypt Data on End-User Devices</title>
    <prop name="label" value="CIS Safeguard 3.6"/>
    <prop name="sort-id" value="cisc-03.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-3.6_stmt">
-    <p>Encrypt data on end-user devices containing sensitive data. Example implementations can include, Windows BitLocker®, Apple FileVault®, Linux® dm-crypt.</p>
+    <p>Encrypt data on end-user devices containing sensitive data. Example implementations can
+     include, Windows BitLocker®, Apple FileVault®, Linux® dm-crypt.</p>
    </part>
   </control>
   <control id="cisc-3.7">
    <title>Establish and Maintain a Data Classification Scheme</title>
    <prop name="label" value="CIS Safeguard 3.7"/>
    <prop name="sort-id" value="cisc-03.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.1"/>
    <link rel="dependency" href="cisc-3.2"/>
    <part name="statement" id="cisc-3.7_stmt">
-    <p>Establish and maintain an overall data classification scheme for the enterprise. Enterprises may use labels, such as “Sensitive”, “Confidential” and “Public”, and classify their data according to those labels. Review and update the classification scheme annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain an overall data classification scheme for the enterprise. Enterprises
+     may use labels, such as “Sensitive”, “Confidential” and “Public”, and classify their data
+     according to those labels. Review and update the classification scheme annually, or when
+     significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-3.8">
    <title>Document Data Flows</title>
    <prop name="label" value="CIS Safeguard 3.8"/>
    <prop name="sort-id" value="cisc-03.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.1"/>
    <link rel="dependency" href="cisc-3.2"/>
    <part name="statement" id="cisc-3.8_stmt">
-    <p>Document data flows. Data flow documentation includes service provider data flows and should be based on the enterprise?s data management process. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Document data flows. Data flow documentation includes service provider data flows and should
+     be based on the enterprise?s data management process. Review and update documentation annually,
+     or when significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-3.9">
    <title>Encrypt Data on Removable Media</title>
    <prop name="label" value="CIS Safeguard 3.9"/>
    <prop name="sort-id" value="cisc-03.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
@@ -543,100 +469,73 @@
    <title>Encrypt Sensitive Data in Transit</title>
    <prop name="label" value="CIS Safeguard 3.10"/>
    <prop name="sort-id" value="cisc-03.10"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.2"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-3.10_stmt">
-    <p>Encrypt sensitive data in transit. Example implementations can include, Transport Layer Security (TLS) and Open Secure Shell (OpenSSH).</p>
+    <p>Encrypt sensitive data in transit. Example implementations can include, Transport Layer
+     Security (TLS) and Open Secure Shell (OpenSSH).</p>
    </part>
   </control>
   <control id="cisc-3.11">
    <title>Encrypt Sensitive Data At Rest</title>
    <prop name="label" value="CIS Safeguard 3.11"/>
    <prop name="sort-id" value="cisc-03.11"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-3.11_stmt">
-    <p>Encrypt sensitive data at rest on servers, applications, and databases containing sensitive data. Storage-layer encryption, also known as server-side encryption, meets the minimum requirement of this Safeguard. Additional encryption methods may include application-layer encryption, also known as client-side encryption, where access to the data storage device(s) does not permit access to the plain-text data.</p>
+    <p>Encrypt sensitive data at rest on servers, applications, and databases containing sensitive
+     data. Storage-layer encryption, also known as server-side encryption, meets the minimum
+     requirement of this Safeguard. Additional encryption methods may include application-layer
+     encryption, also known as client-side encryption, where access to the data storage device(s)
+     does not permit access to the plain-text data.</p>
    </part>
   </control>
   <control id="cisc-3.12">
    <title>Segment Data Processing and Storage Based on Sensitivity</title>
    <prop name="label" value="CIS Safeguard 3.12"/>
    <prop name="sort-id" value="cisc-03.12"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="nhttps://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="nhttps://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-3.2"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-3.12_stmt">
-    <p>Segment data processing and storage, based on the sensitivity of the data. Do not process sensitive data on enterprise assets intended for lower sensitivity data.</p>
+    <p>Segment data processing and storage, based on the sensitivity of the data. Do not process
+     sensitive data on enterprise assets intended for lower sensitivity data.</p>
    </part>
   </control>
   <control id="cisc-3.13">
    <title>Segment Data Processing and Storage Based on Sensitivity</title>
    <prop name="label" value="CIS Safeguard 3.13"/>
    <prop name="sort-id" value="cisc-03.13"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="nhttps://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="nhttps://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-3.2"/>
    <part name="statement" id="cisc-3.13_stmt">
-    <p>Implement an automated tool, such as a host-based Data Loss Prevention (DLP) tool to identify all sensitive data stored, processed, or transmitted through enterprise assets, including those located onsite or at a remote service provider, and update the enterprise’s sensitive data inventory.</p>
+    <p>Implement an automated tool, such as a host-based Data Loss Prevention (DLP) tool to identify
+     all sensitive data stored, processed, or transmitted through enterprise assets, including those
+     located onsite or at a remote service provider, and update the enterprise’s sensitive data
+     inventory.</p>
    </part>
   </control>
   <control id="cisc-3.14">
    <title>Log Sensitive Data Access</title>
    <prop name="label" value="CIS Safeguard 3.14"/>
    <prop name="sort-id" value="cisc-03.14"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="nhttps://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="nhttps://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
@@ -644,303 +543,245 @@
     <p>Log sensitive data access, including modification and disposal.</p>
    </part>
   </control>
- </control> 
+ </control>
  <control id="cisc-4">
   <title>Secure Configuration of Enterprise Assets and Software</title>
   <prop name="label" value="CIS Control 4"/>
   <prop name="sort-id" value="cisc-04"/>
   <part name="statement" id="cisc-4_stmt">
-   <p>Establish and maintain the secure configuration of enterprise assets (end-user devices, including portable and mobile; network devices; non-computing/IoT devices; and servers) and software (operating systems and applications).</p>
+   <p>Establish and maintain the secure configuration of enterprise assets (end-user devices,
+    including portable and mobile; network devices; non-computing/IoT devices; and servers) and
+    software (operating systems and applications).</p>
   </part>
   <part name="guidance" id="cisc-4_gdn">
-   <p>As delivered from manufacturers and resellers, the default configurations for enterprise assets and software are normally geared towards ease-of-deployment and ease-of-use rather than security. Basic controls, open services and ports, default accounts or passwords, pre-configured Domain Name System (DNS) settings, older (vulnerable) protocols, and pre-installation of unnecessary software can all be exploitable if left in their default state. Further, these security configuration updates need to be managed and maintained over the life cycle of enterprise assets and software. Configuration updates need to be tracked and approved through configuration management workflow process to maintain a record that can be reviewed for compliance, leveraged for incident response, and to support audits. This CIS Control is important to on-premises devices, as well as remote devices, network devices, and cloud environments.</p>
-   <p>Service providers play a key role in modern infrastructures, especially for smaller enterprises. They often are not set up by default in the most secure configuration to provide flexibility for their customers to apply their own security policies. Therefore, the presence of default accounts or passwords, excessive access, or unnecessary services are common in default configurations. These could introduce weaknesses that are under the responsibility of the enterprise that is using the software, rather than the service provider. This extends to ongoing management and updates, as some Platform as a Service (PaaS) only extend to the operating system, so patching and updating hosted applications are under the responsibility of the enterprise.</p>
-   <p>Even after a strong initial configuration is developed and applied, it must be continually managed to avoid degrading security as software is updated or patched, new security vulnerabilities are reported, and configurations are “tweaked,” to allow the installation of new software or to support new operational requirements.</p>
+   <p>As delivered from manufacturers and resellers, the default configurations for enterprise
+    assets and software are normally geared towards ease-of-deployment and ease-of-use rather than
+    security. Basic controls, open services and ports, default accounts or passwords, pre-configured
+    Domain Name System (DNS) settings, older (vulnerable) protocols, and pre-installation of
+    unnecessary software can all be exploitable if left in their default state. Further, these
+    security configuration updates need to be managed and maintained over the life cycle of
+    enterprise assets and software. Configuration updates need to be tracked and approved through
+    configuration management workflow process to maintain a record that can be reviewed for
+    compliance, leveraged for incident response, and to support audits. This CIS Control is
+    important to on-premises devices, as well as remote devices, network devices, and cloud
+    environments.</p>
+   <p>Service providers play a key role in modern infrastructures, especially for smaller
+    enterprises. They often are not set up by default in the most secure configuration to provide
+    flexibility for their customers to apply their own security policies. Therefore, the presence of
+    default accounts or passwords, excessive access, or unnecessary services are common in default
+    configurations. These could introduce weaknesses that are under the responsibility of the
+    enterprise that is using the software, rather than the service provider. This extends to ongoing
+    management and updates, as some Platform as a Service (PaaS) only extend to the operating
+    system, so patching and updating hosted applications are under the responsibility of the
+    enterprise.</p>
+   <p>Even after a strong initial configuration is developed and applied, it must be continually
+    managed to avoid degrading security as software is updated or patched, new security
+    vulnerabilities are reported, and configurations are “tweaked,” to allow the installation of new
+    software or to support new operational requirements.</p>
   </part>
   <control id="cisc-4.1">
    <title>Establish and Maintain a Secure Configuration Process</title>
    <prop name="label" value="CIS Safeguard 4.1"/>
    <prop name="sort-id" value="cisc-04.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-4.1_stmt">
-    <p>Establish and maintain a secure configuration process for enterprise assets (end-user devices, including portable and mobile, non-computing/IoT devices, and servers) and software (operating systems and applications). Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a secure configuration process for enterprise assets (end-user
+     devices, including portable and mobile, non-computing/IoT devices, and servers) and software
+     (operating systems and applications). Review and update documentation annually, or when
+     significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-4.2">
    <title>Establish and Maintain a Secure Configuration Process for Network Infrastructure</title>
    <prop name="label" value="CIS Safeguard 4.2"/>
    <prop name="sort-id" value="cisc-04.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-4.2_stmt">
-    <p>Establish and maintain a secure configuration process for network devices. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a secure configuration process for network devices. Review and update
+     documentation annually, or when significant enterprise changes occur that could impact this
+     Safeguard.</p>
    </part>
   </control>
   <control id="cisc-4.3">
    <title>Configure Automatic Session Locking on Enterprise Assets</title>
    <prop name="label" value="CIS Safeguard 4.3"/>
    <prop name="sort-id" value="cisc-04.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-4.3_stmt">
-    <p>Configure automatic session locking on enterprise assets after a defined period of inactivity. For general purpose operating systems, the period must not exceed 15 minutes. For mobile end-user devices, the period must not exceed 2 minutes.</p>
+    <p>Configure automatic session locking on enterprise assets after a defined period of
+     inactivity. For general purpose operating systems, the period must not exceed 15 minutes. For
+     mobile end-user devices, the period must not exceed 2 minutes.</p>
    </part>
   </control>
   <control id="cisc-4.4">
    <title>Implement and Manage a Firewall on Servers</title>
    <prop name="label" value="CIS Safeguard 4.4"/>
    <prop name="sort-id" value="cisc-04.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.4_stmt">
-    <p>Implement and manage a firewall on servers, where supported. Example implementations include a virtual firewall, operating system firewall, or a third-party firewall agent.</p>
+    <p>Implement and manage a firewall on servers, where supported. Example implementations include
+     a virtual firewall, operating system firewall, or a third-party firewall agent.</p>
    </part>
   </control>
   <control id="cisc-4.5">
    <title>Implement and Manage a Firewall on End-User Devices</title>
    <prop name="label" value="CIS Safeguard 4.5"/>
    <prop name="sort-id" value="cisc-04.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.5_stmt">
-    <p>Implement and manage a host-based firewall or port-filtering tool on end-user devices, with a default-deny rule that drops all traffic except those services and ports that are explicitly allowed.</p>
+    <p>Implement and manage a host-based firewall or port-filtering tool on end-user devices, with a
+     default-deny rule that drops all traffic except those services and ports that are explicitly
+     allowed.</p>
    </part>
   </control>
   <control id="cisc-4.6">
    <title>Securely Manage Enterprise Assets and Software</title>
    <prop name="label" value="CIS Safeguard 4.6"/>
    <prop name="sort-id" value="cisc-04.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.6_stmt">
-    <p>Securely manage enterprise assets and software. Example implementations include managing configuration through version-controlled-infrastructure-as-code and accessing administrative interfaces over secure network protocols, such as Secure Shell (SSH) and Hypertext Transfer Protocol Secure (HTTPS). Do not use insecure management protocols, such as Telnet (Teletype Network) and HTTP, unless operationally essential.</p>
+    <p>Securely manage enterprise assets and software. Example implementations include managing
+     configuration through version-controlled-infrastructure-as-code and accessing administrative
+     interfaces over secure network protocols, such as Secure Shell (SSH) and Hypertext Transfer
+     Protocol Secure (HTTPS). Do not use insecure management protocols, such as Telnet (Teletype
+     Network) and HTTP, unless operationally essential.</p>
    </part>
   </control>
   <control id="cisc-4.7">
    <title>Manage Default Accounts on Enterprise Assets and Software</title>
    <prop name="label" value="CIS Safeguard 4.7"/>
    <prop name="sort-id" value="cisc-04.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="potect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="potect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-5.2"/>
    <part name="statement" id="cisc-4.7_stmt">
-    <p>Manage default accounts on enterprise assets and software, such as root, administrator, and other pre-configured vendor accounts. Example implementations can include: disabling default accounts or making them unusable.</p>
+    <p>Manage default accounts on enterprise assets and software, such as root, administrator, and
+     other pre-configured vendor accounts. Example implementations can include: disabling default
+     accounts or making them unusable.</p>
    </part>
   </control>
   <control id="cisc-4.8">
    <title>Uninstall or Disable Unnecessary Services on Enterprise Assets and Software</title>
    <prop name="label" value="CIS Safeguard 4.8"/>
    <prop name="sort-id" value="cisc-04.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-4.8_stmt">
-    <p>Uninstall or disable unnecessary services on enterprise assets and software, such as an unused file sharing service, web application module, or service function.</p>
+    <p>Uninstall or disable unnecessary services on enterprise assets and software, such as an
+     unused file sharing service, web application module, or service function.</p>
    </part>
   </control>
   <control id="cisc-4.9">
    <title>Configure Trusted DNS Servers on Enterprise Assets</title>
    <prop name="label" value="CIS Safeguard 4.9"/>
    <prop name="sort-id" value="cisc-04.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.9_stmt">
-    <p>Configure trusted DNS servers on enterprise assets. Example implementations include: configuring assets to use enterprise-controlled DNS servers and/or reputable externally accessible DNS servers.</p>
+    <p>Configure trusted DNS servers on enterprise assets. Example implementations include:
+     configuring assets to use enterprise-controlled DNS servers and/or reputable externally
+     accessible DNS servers.</p>
    </part>
   </control>
   <control id="cisc-4.10">
    <title>Enforce Automatic Device Lockout on Portable End-User Devices</title>
    <prop name="label" value="CIS Safeguard 4.10"/>
    <prop name="sort-id" value="cisc-04.10"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.10_stmt">
-    <p>Enforce automatic device lockout following a predetermined threshold of local failed authentication attempts on portable end-user devices, where supported. For laptops, do not allow more than 20 failed authentication attempts; for tablets and smartphones, no more than 10 failed authentication attempts. Example implementations include Microsoft? InTune Device Lock and Apple? Configuration Profile maxFailedAttempts.</p>
+    <p>Enforce automatic device lockout following a predetermined threshold of local failed
+     authentication attempts on portable end-user devices, where supported. For laptops, do not
+     allow more than 20 failed authentication attempts; for tablets and smartphones, no more than 10
+     failed authentication attempts. Example implementations include Microsoft? InTune Device Lock
+     and Apple? Configuration Profile maxFailedAttempts.</p>
    </part>
   </control>
   <control id="cisc-4.11">
    <title>Enforce Remote Wipe Capability on Portable End-User Devices</title>
    <prop name="label" value="CIS Safeguard 4.11"/>
    <prop name="sort-id" value="cisc-04.11"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.11_stmt">
-    <p>Remotely wipe enterprise data from enterprise-owned portable end-user devices when deemed appropriate such as lost or stolen devices, or when an individual no longer supports the enterprise.</p>
+    <p>Remotely wipe enterprise data from enterprise-owned portable end-user devices when deemed
+     appropriate such as lost or stolen devices, or when an individual no longer supports the
+     enterprise.</p>
    </part>
   </control>
   <control id="cisc-4.12">
    <title>Separate Enterprise Workspaces on Mobile End-User Devices</title>
    <prop name="label" value="CIS Safeguard 4.12"/>
    <prop name="sort-id" value="cisc-04.12"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="nhttps://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="nhttps://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-4.12_stmt">
-    <p>Ensure separate enterprise workspaces are used on mobile end-user devices, where supported. Example implementations include using an Apple? Configuration Profile or Android? Work Profile to separate enterprise applications and data from personal applications and data.</p>
+    <p>Ensure separate enterprise workspaces are used on mobile end-user devices, where supported.
+     Example implementations include using an Apple? Configuration Profile or Android? Work Profile
+     to separate enterprise applications and data from personal applications and data.</p>
    </part>
   </control>
  </control>
@@ -949,145 +790,118 @@
   <prop name="label" value="CIS Control 5"/>
   <prop name="sort-id" value="cisc-05"/>
   <part name="statement" id="cisc-5_stmt">
-   <p>Use processes and tools to assign and manage authorization to credentials for user accounts, including administrator accounts, as well as service accounts, to enterprise assets and software.</p>
+   <p>Use processes and tools to assign and manage authorization to credentials for user accounts,
+    including administrator accounts, as well as service accounts, to enterprise assets and
+    software.</p>
   </part>
   <part name="guidance" id="cisc-5_gdn">
-   <p>It is easier for an external or internal threat actor to gain unauthorized access to enterprise assets or data through using valid user credentials than through “hacking” the environment. There are many ways to covertly obtain access to user accounts, including: weak passwords, accounts still valid after a user leaves the enterprise, dormant or lingering test accounts, shared accounts that have not been changed in months or years, service accounts embedded in applications for scripts, a user having the same password as one they use for an online account that has been compromised (in a public password dump), social engineering a user to give their password, or using malware to capture passwords or tokens in memory or over the network.</p>
-   <p>Administrative, or highly privileged, accounts are a particular target, because they allow attackers to add other accounts, or make changes to assets that could make them more vulnerable to other attacks. Service accounts are also sensitive, as they are often shared among teams, internal and external to the enterprise, and sometimes not known about, only to be revealed in standard account management audits.</p>
-   <p>Finally, account logging and monitoring is a critical component of security operations. While account logging and monitoring are covered in CIS Control 8 (Audit Log Management), it is important in the development of a comprehensive Identity and Access Management (IAM) program.</p>
+   <p>It is easier for an external or internal threat actor to gain unauthorized access to
+    enterprise assets or data through using valid user credentials than through “hacking” the
+    environment. There are many ways to covertly obtain access to user accounts, including: weak
+    passwords, accounts still valid after a user leaves the enterprise, dormant or lingering test
+    accounts, shared accounts that have not been changed in months or years, service accounts
+    embedded in applications for scripts, a user having the same password as one they use for an
+    online account that has been compromised (in a public password dump), social engineering a user
+    to give their password, or using malware to capture passwords or tokens in memory or over the
+    network.</p>
+   <p>Administrative, or highly privileged, accounts are a particular target, because they allow
+    attackers to add other accounts, or make changes to assets that could make them more vulnerable
+    to other attacks. Service accounts are also sensitive, as they are often shared among teams,
+    internal and external to the enterprise, and sometimes not known about, only to be revealed in
+    standard account management audits.</p>
+   <p>Finally, account logging and monitoring is a critical component of security operations. While
+    account logging and monitoring are covered in CIS Control 8 (Audit Log Management), it is
+    important in the development of a comprehensive Identity and Access Management (IAM)
+    program.</p>
   </part>
   <control id="cisc-5.1">
    <title>Establish and Maintain an Inventory of Accounts</title>
    <prop name="label" value="CIS Safeguard 5.1"/>
    <prop name="sort-id" value="cisc-05.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-5.1_stmt">
-    <p>Establish and maintain an inventory of all accounts managed in the enterprise. The inventory must include both user and administrator accounts. The inventory, at a minimum, should contain the person’s name, username, start/stop dates, and department. Validate that all active accounts are authorized, on a recurring schedule at a minimum quarterly, or more frequently.</p>
+    <p>Establish and maintain an inventory of all accounts managed in the enterprise. The inventory
+     must include both user and administrator accounts. The inventory, at a minimum, should contain
+     the person’s name, username, start/stop dates, and department. Validate that all active
+     accounts are authorized, on a recurring schedule at a minimum quarterly, or more
+     frequently.</p>
    </part>
   </control>
   <control id="cisc-5.2">
    <title>Use Unique Passwords</title>
    <prop name="label" value="CIS Safeguard 5.2"/>
    <prop name="sort-id" value="cisc-05.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-5.2_stmt">
-    <p>Use unique passwords for all enterprise assets. Best practice implementation includes, at a minimum, an 8-character password for accounts using MFA and a 14-character password for accounts not using MFA.</p>
+    <p>Use unique passwords for all enterprise assets. Best practice implementation includes, at a
+     minimum, an 8-character password for accounts using MFA and a 14-character password for
+     accounts not using MFA.</p>
    </part>
   </control>
   <control id="cisc-5.3">
    <title>Disable Dormant Accounts</title>
    <prop name="label" value="CIS Safeguard 5.3"/>
    <prop name="sort-id" value="cisc-05.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-5.3_stmt">
-    <p>Delete or disable any dormant accounts after a period of 45 days of inactivity, where supported</p>
+    <p>Delete or disable any dormant accounts after a period of 45 days of inactivity, where
+     supported</p>
    </part>
   </control>
   <control id="cisc-5.4">
    <title>Restrict Administrator Privileges to Dedicated Administrator Accounts</title>
    <prop name="label" value="CIS Safeguard 5.4"/>
    <prop name="sort-id" value="cisc-05.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-5.4_stmt">
-    <p>Restrict administrator privileges to dedicated administrator accounts on enterprise assets. Conduct general computing activities, such as internet browsing, email, and productivity suite use, from the user’s primary, non-privileged account.</p>
+    <p>Restrict administrator privileges to dedicated administrator accounts on enterprise assets.
+     Conduct general computing activities, such as internet browsing, email, and productivity suite
+     use, from the user’s primary, non-privileged account.</p>
    </part>
   </control>
   <control id="cisc-5.5">
    <title>Establish and Maintain an Inventory of Service Accounts</title>
    <prop name="label" value="CIS Safeguard 5.5"/>
    <prop name="sort-id" value="cisc-05.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-6.6"/>
    <part name="statement" id="cisc-5.5_stmt">
-    <p>Establish and maintain an inventory of service accounts. The inventory, at a minimum, must contain department owner, review date, and purpose. Perform service account reviews to validate that all active accounts are authorized, on a recurring schedule at a minimum quarterly, or more frequently.</p>
+    <p>Establish and maintain an inventory of service accounts. The inventory, at a minimum, must
+     contain department owner, review date, and purpose. Perform service account reviews to validate
+     that all active accounts are authorized, on a recurring schedule at a minimum quarterly, or
+     more frequently.</p>
    </part>
   </control>
   <control id="cisc-5.6">
    <title>Centralize Account Management</title>
    <prop name="label" value="CIS Safeguard 5.6"/>
    <prop name="sort-id" value="cisc-05.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-5.6_stmt">
@@ -1100,104 +914,86 @@
   <prop name="label" value="CIS Control 6"/>
   <prop name="sort-id" value="cisc-06"/>
   <part name="statement" id="cisc-6_stmt">
-   <p>Use processes and tools to create, assign, manage, and revoke access credentials and privileges for user, administrator, and service accounts for enterprise assets and software.</p>
+   <p>Use processes and tools to create, assign, manage, and revoke access credentials and
+    privileges for user, administrator, and service accounts for enterprise assets and software.</p>
   </part>
   <part name="guidance" id="cisc-6_gdn">
-   <p>Where CIS Control 5 deals specifically with account management, CIS Control 6 focuses on managing what access these accounts have, ensuring users only have access to the data or enterprise assets appropriate for their role, and ensuring that there is strong authentication for critical or sensitive enterprise data or functions. Accounts should only have the minimal authorization needed for the role. Developing consistent access rights for each role and assigning roles to users is a best practice. Developing a program for complete provision and de-provisioning access is also important. Centralizing this function is ideal.</p>
-   <p>There are some user activities that pose greater risk to an enterprise, either because they are accessed from untrusted networks, or performing administrator functions that allow the ability to add, change, or remove other accounts, or make configuration changes to operating systems or applications to make them less secure. This also enforces the importance of using MFA and Privileged Access Management (PAM) tools.</p>
-   <p>Some users have access to enterprise assets or data they do not need for their role; this might be due to an immature process that gives all users all access, or lingering access as users change roles within the enterprise over time. Local administrator privileges to users’ laptops is also an issue, as any malicious code installed or downloaded by the user can have greater impact on the enterprise asset running as administrator. User, administrator, and service account access should be based on enterprise role and need.</p>
+   <p>Where CIS Control 5 deals specifically with account management, CIS Control 6 focuses on
+    managing what access these accounts have, ensuring users only have access to the data or
+    enterprise assets appropriate for their role, and ensuring that there is strong authentication
+    for critical or sensitive enterprise data or functions. Accounts should only have the minimal
+    authorization needed for the role. Developing consistent access rights for each role and
+    assigning roles to users is a best practice. Developing a program for complete provision and
+    de-provisioning access is also important. Centralizing this function is ideal.</p>
+   <p>There are some user activities that pose greater risk to an enterprise, either because they
+    are accessed from untrusted networks, or performing administrator functions that allow the
+    ability to add, change, or remove other accounts, or make configuration changes to operating
+    systems or applications to make them less secure. This also enforces the importance of using MFA
+    and Privileged Access Management (PAM) tools.</p>
+   <p>Some users have access to enterprise assets or data they do not need for their role; this
+    might be due to an immature process that gives all users all access, or lingering access as
+    users change roles within the enterprise over time. Local administrator privileges to users’
+    laptops is also an issue, as any malicious code installed or downloaded by the user can have
+    greater impact on the enterprise asset running as administrator. User, administrator, and
+    service account access should be based on enterprise role and need.</p>
   </part>
   <control id="cisc-6.1">
    <title>Establish an Access Granting Process</title>
    <prop name="label" value="CIS Safeguard 6.1"/>
    <prop name="sort-id" value="cisc-06.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-6.1_stmt">
-    <p>Establish and follow a process, preferably automated, for granting access to enterprise assets upon new hire, rights grant, or role change of a user.</p>
+    <p>Establish and follow a process, preferably automated, for granting access to enterprise
+     assets upon new hire, rights grant, or role change of a user.</p>
    </part>
   </control>
   <control id="cisc-6.2">
    <title>Establish an Access Revoking Process</title>
    <prop name="label" value="CIS Safeguard 6.2"/>
    <prop name="sort-id" value="cisc-06.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-6.2_stmt">
-    <p>Establish and follow a process, preferably automated, for revoking access to enterprise assets, through disabling accounts immediately upon termination, rights revocation, or role change of a user. Disabling accounts, instead of deleting accounts, may be necessary to preserve audit trails.</p>
+    <p>Establish and follow a process, preferably automated, for revoking access to enterprise
+     assets, through disabling accounts immediately upon termination, rights revocation, or role
+     change of a user. Disabling accounts, instead of deleting accounts, may be necessary to
+     preserve audit trails.</p>
    </part>
   </control>
   <control id="cisc-6.3">
    <title>Require MFA for Externally-Exposed Applications</title>
    <prop name="label" value="CIS Safeguard 6.3"/>
    <prop name="sort-id" value="cisc-06.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-6.3_stmt">
-    <p>Require all externally-exposed enterprise or third-party applications to enforce MFA, where supported. Enforcing MFA through a directory service or SSO provider is a satisfactory implementation of this Safeguard.</p>
+    <p>Require all externally-exposed enterprise or third-party applications to enforce MFA, where
+     supported. Enforcing MFA through a directory service or SSO provider is a satisfactory
+     implementation of this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-6.4">
    <title>Require MFA for Remote Network Access</title>
    <prop name="label" value="CIS Safeguard 6.4"/>
    <prop name="sort-id" value="cisc-06.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-6.4_stmt">
@@ -1208,87 +1004,62 @@
    <title>Require MFA for Administrative Access</title>
    <prop name="label" value="CIS Safeguard 6.5"/>
    <prop name="sort-id" value="cisc-06.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-6.5_stmt">
-    <p>Require MFA for all administrative access accounts, where supported, on all enterprise assets, whether managed on-site or through a third-party provider.</p>
+    <p>Require MFA for all administrative access accounts, where supported, on all enterprise
+     assets, whether managed on-site or through a third-party provider.</p>
    </part>
   </control>
   <control id="cisc-6.6">
    <title>Establish and Maintain an Inventory of Authentication and Authorization Systems</title>
    <prop name="label" value="CIS Safeguard 6.6"/>
    <prop name="sort-id" value="cisc-06.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-6.6_stmt">
-    <p>Establish and maintain an inventory of the enterprise’s authentication and authorization systems, including those hosted on-site or at a remote service provider. Review and update the inventory, at a minimum, annually, or more frequently.</p>
+    <p>Establish and maintain an inventory of the enterprise’s authentication and authorization
+     systems, including those hosted on-site or at a remote service provider. Review and update the
+     inventory, at a minimum, annually, or more frequently.</p>
    </part>
   </control>
   <control id="cisc-6.7">
    <title>Centralize Access Control</title>
    <prop name="label" value="CIS Safeguard 6.7"/>
    <prop name="sort-id" value="cisc-06.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="users"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="users"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-6.7_stmt">
-    <p>Centralize access control for all enterprise assets through a directory service or SSO provider, where supported.</p>
+    <p>Centralize access control for all enterprise assets through a directory service or SSO
+     provider, where supported.</p>
    </part>
   </control>
   <control id="cisc-6.8">
    <title>Centralize Access Control</title>
    <prop name="label" value="CIS Safeguard 6.8"/>
    <prop name="sort-id" value="cisc-06.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-5.1"/>
    <part name="statement" id="cisc-6.8_stmt">
-    <p>Define and maintain role-based access control, through determining and documenting the access rights necessary for each role within the enterprise to successfully carry out its assigned duties. Perform access control reviews of enterprise assets to validate that all privileges are authorized, on a recurring schedule at a minimum annually, or more frequently.</p>
+    <p>Define and maintain role-based access control, through determining and documenting the access
+     rights necessary for each role within the enterprise to successfully carry out its assigned
+     duties. Perform access control reviews of enterprise assets to validate that all privileges are
+     authorized, on a recurring schedule at a minimum annually, or more frequently.</p>
    </part>
   </control>
  </control>
@@ -1297,323 +1068,263 @@
   <prop name="label" value="CIS Control 7"/>
   <prop name="sort-id" value="cisc-07"/>
   <part name="statement" id="cisc-7_stmt">
-   <p>Develop a plan to continuously assess and track vulnerabilities on all enterprise assets within the enterprise’s infrastructure, in order to remediate, and minimize, the window of opportunity for attackers. Monitor public and private industry sources for new threat and vulnerability information.</p>
+   <p>Develop a plan to continuously assess and track vulnerabilities on all enterprise assets
+    within the enterprise’s infrastructure, in order to remediate, and minimize, the window of
+    opportunity for attackers. Monitor public and private industry sources for new threat and
+    vulnerability information.</p>
   </part>
   <part name="guidance" id="cisc-7_gdn">
-   <p>Cyber defenders are constantly being challenged from attackers who are looking for vulnerabilities within their infrastructure to exploit and gain access. Defenders must have timely threat information available to them about: software updates, patches, security advisories, threat bulletins, etc., and they should regularly review their environment to identify these vulnerabilities before the attackers do. Understanding and managing vulnerabilities is a continuous activity, requiring focus of time, attention, and resources.</p>
-   <p>Attackers have access to the same information and can often take advantage of vulnerabilities more quickly than an enterprise can remediate. While there is a gap in time from a vulnerability being known to when it is patched, defenders can prioritize which vulnerabilities are most impactful to the enterprise, or likely to be exploited first due to ease of use. For example, when researchers or the community report new vulnerabilities, vendors have to develop and deploy patches, indicators of compromise (IOCs), and updates. Defenders need to assess the risk of the new vulnerability to the enterprise, regression-test patches , and install the patch.</p>
-   <p>There is never perfection in this process. Attackers might be using an exploit to a vulnerability that is not known within the security community. They might have developed an exploit to this vulnerability referred to as a “zero-day” exploit. Once the vulnerability is known in the community, the process mentioned above starts. Therefore, defenders must keep in mind that an exploit might already exist when the vulnerability is widely socialized. Sometimes vulnerabilities might be known within a closed community (e.g., vendor still developing a fix) for weeks, months, or years before it is disclosed publicly. Defenders have to be aware that there might always be vulnerabilities they cannot remediate, and therefore need to use other controls to mitigate.</p>
-   <p>Enterprises that do not assess their infrastructure for vulnerabilities and proactively address discovered flaws face a significant likelihood of having their enterprise assets compromised. Defenders face particular challenges in scaling remediation across an entire enterprise, and prioritizing actions with conflicting priorities, while not impacting the enterprise’s business or mission.</p>
+   <p>Cyber defenders are constantly being challenged from attackers who are looking for
+    vulnerabilities within their infrastructure to exploit and gain access. Defenders must have
+    timely threat information available to them about: software updates, patches, security
+    advisories, threat bulletins, etc., and they should regularly review their environment to
+    identify these vulnerabilities before the attackers do. Understanding and managing
+    vulnerabilities is a continuous activity, requiring focus of time, attention, and resources.</p>
+   <p>Attackers have access to the same information and can often take advantage of vulnerabilities
+    more quickly than an enterprise can remediate. While there is a gap in time from a vulnerability
+    being known to when it is patched, defenders can prioritize which vulnerabilities are most
+    impactful to the enterprise, or likely to be exploited first due to ease of use. For example,
+    when researchers or the community report new vulnerabilities, vendors have to develop and deploy
+    patches, indicators of compromise (IOCs), and updates. Defenders need to assess the risk of the
+    new vulnerability to the enterprise, regression-test patches , and install the patch.</p>
+   <p>There is never perfection in this process. Attackers might be using an exploit to a
+    vulnerability that is not known within the security community. They might have developed an
+    exploit to this vulnerability referred to as a “zero-day” exploit. Once the vulnerability is
+    known in the community, the process mentioned above starts. Therefore, defenders must keep in
+    mind that an exploit might already exist when the vulnerability is widely socialized. Sometimes
+    vulnerabilities might be known within a closed community (e.g., vendor still developing a fix)
+    for weeks, months, or years before it is disclosed publicly. Defenders have to be aware that
+    there might always be vulnerabilities they cannot remediate, and therefore need to use other
+    controls to mitigate.</p>
+   <p>Enterprises that do not assess their infrastructure for vulnerabilities and proactively
+    address discovered flaws face a significant likelihood of having their enterprise assets
+    compromised. Defenders face particular challenges in scaling remediation across an entire
+    enterprise, and prioritizing actions with conflicting priorities, while not impacting the
+    enterprise’s business or mission.</p>
   </part>
   <control id="cisc-7.1">
    <title>Establish and Maintain a Vulnerability Management Process</title>
    <prop name="label" value="CIS Safeguard 7.1"/>
    <prop name="sort-id" value="cisc-07.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-7.1_stmt">
-    <p>Establish and maintain a documented vulnerability management process for enterprise assets. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a documented vulnerability management process for enterprise assets.
+     Review and update documentation annually, or when significant enterprise changes occur that
+     could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-7.2">
    <title>Establish and Maintain a Remediation Process</title>
    <prop name="label" value="CIS Safeguard 7.2"/>
    <prop name="sort-id" value="cisc-07.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-7.2_stmt">
-    <p>Establish and maintain a risk-based remediation strategy documented in a remediation process, with monthly, or more frequent, reviews.</p>
+    <p>Establish and maintain a risk-based remediation strategy documented in a remediation process,
+     with monthly, or more frequent, reviews.</p>
    </part>
   </control>
   <control id="cisc-7.3">
    <title>Perform Automated Operating System Patch Management</title>
    <prop name="label" value="CIS Safeguard 7.3"/>
    <prop name="sort-id" value="cisc-07.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-7.3_stmt">
-    <p>Perform operating system updates on enterprise assets through automated patch management on a monthly, or more frequent, basis.</p>
+    <p>Perform operating system updates on enterprise assets through automated patch management on a
+     monthly, or more frequent, basis.</p>
    </part>
   </control>
   <control id="cisc-7.4">
    <title>Perform Automated Application Patch Management</title>
    <prop name="label" value="CIS Safeguard 7.4"/>
    <prop name="sort-id" value="cisc-07.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-7.4_stmt">
-    <p>Perform application updates on enterprise assets through automated patch management on a monthly, or more frequent, basis.</p>
+    <p>Perform application updates on enterprise assets through automated patch management on a
+     monthly, or more frequent, basis.</p>
    </part>
   </control>
   <control id="cisc-7.5">
    <title>Perform Automated Vulnerability Scans of Internal Enterprise Assets</title>
    <prop name="label" value="CIS Safeguard 7.5"/>
    <prop name="sort-id" value="cisc-07.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-7.5_stmt">
-    <p>Perform automated vulnerability scans of internal enterprise assets on a quarterly, or more frequent, basis. Conduct both authenticated and unauthenticated scans, using a SCAP-compliant vulnerability scanning tool.</p>
+    <p>Perform automated vulnerability scans of internal enterprise assets on a quarterly, or more
+     frequent, basis. Conduct both authenticated and unauthenticated scans, using a SCAP-compliant
+     vulnerability scanning tool.</p>
    </part>
   </control>
   <control id="cisc-7.6">
    <title>Perform Automated Vulnerability Scans of Externally-Exposed Enterprise Assets</title>
    <prop name="label" value="CIS Safeguard 7.6"/>
    <prop name="sort-id" value="cisc-07.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-7.6_stmt">
-    <p>Perform automated vulnerability scans of externally-exposed enterprise assets using a SCAP-compliant vulnerability scanning tool. Perform scans on a monthly, or more frequent, basis.</p>
+    <p>Perform automated vulnerability scans of externally-exposed enterprise assets using a
+     SCAP-compliant vulnerability scanning tool. Perform scans on a monthly, or more frequent,
+     basis.</p>
    </part>
   </control>
   <control id="cisc-7.7">
    <title>Remediate Detected Vulnerabilities</title>
    <prop name="label" value="CIS Safeguard 7.7"/>
    <prop name="sort-id" value="cisc-07.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-7.7_stmt">
-    <p>Remediate detected vulnerabilities in software through processes and tooling on a monthly, or more frequent, basis, based on the remediation process.</p>
+    <p>Remediate detected vulnerabilities in software through processes and tooling on a monthly, or
+     more frequent, basis, based on the remediation process.</p>
    </part>
-  </control> 
+  </control>
  </control>
  <control id="cisc-8">
   <title>Audit Log Management</title>
   <prop name="label" value="CIS Control 8"/>
   <prop name="sort-id" value="cisc-08"/>
   <part name="statement" id="cisc-8_stmt">
-   <p>Collect, alert, review, and retain audit logs of events that could help detect, understand, or recover from an attack.</p>
+   <p>Collect, alert, review, and retain audit logs of events that could help detect, understand, or
+    recover from an attack.</p>
   </part>
   <part name="guidance" id="cisc-8_gdn">
-   <p>Log collection and analysis is critical for an enterprise’s ability to detect malicious activity quickly. Sometimes audit records are the only evidence of a successful attack. Attackers know that many enterprises keep audit logs for compliance purposes, but rarely analyze them. Attackers use this knowledge to hide their location, malicious software, and activities on victim machines. Due to poor or nonexistent log analysis processes, attackers sometimes control victim machines for months or years without anyone in the target enterprise knowing.</p>
-   <p>There are two types of logs that are generally treated and often configured independently: system logs and audit logs. System logs typically provide system-level events that show various system process start/end times, crashes, etc. These are native to systems, and take less configuration to turn on. Audit logs typically include user-level events – when a user logged in, accessed a file, etc. – and take more planning and effort to set up.</p>
-   <p>Logging records are also critical for incident response. After an attack has been detected, log analysis can help enterprises understand the extent of an attack. Complete logging records can show, for example, when and how the attack occurred, what information was accessed, and if data was exfiltrated. Retention of logs is also critical in case a follow-up investigation is required or if an attack remained undetected for a long period of time.</p>
+   <p>Log collection and analysis is critical for an enterprise’s ability to detect malicious
+    activity quickly. Sometimes audit records are the only evidence of a successful attack.
+    Attackers know that many enterprises keep audit logs for compliance purposes, but rarely analyze
+    them. Attackers use this knowledge to hide their location, malicious software, and activities on
+    victim machines. Due to poor or nonexistent log analysis processes, attackers sometimes control
+    victim machines for months or years without anyone in the target enterprise knowing.</p>
+   <p>There are two types of logs that are generally treated and often configured independently:
+    system logs and audit logs. System logs typically provide system-level events that show various
+    system process start/end times, crashes, etc. These are native to systems, and take less
+    configuration to turn on. Audit logs typically include user-level events – when a user logged
+    in, accessed a file, etc. – and take more planning and effort to set up.</p>
+   <p>Logging records are also critical for incident response. After an attack has been detected,
+    log analysis can help enterprises understand the extent of an attack. Complete logging records
+    can show, for example, when and how the attack occurred, what information was accessed, and if
+    data was exfiltrated. Retention of logs is also critical in case a follow-up investigation is
+    required or if an attack remained undetected for a long period of time.</p>
   </part>
   <control id="cisc-8.1">
    <title>Establish and Maintain an Audit Log Management Process</title>
    <prop name="label" value="CIS Safeguard 8.1"/>
    <prop name="sort-id" value="cisc-08.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-8.1_stmt">
-    <p>Establish and maintain an audit log management process that defines the enterprise’s logging requirements. At a minimum, address the collection, review, and retention of audit logs for enterprise assets. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain an audit log management process that defines the enterprise’s logging
+     requirements. At a minimum, address the collection, review, and retention of audit logs for
+     enterprise assets. Review and update documentation annually, or when significant enterprise
+     changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-8.2">
    <title>Collect Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.2"/>
    <prop name="sort-id" value="cisc-08.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-8.1"/>
    <part name="statement" id="cisc-8.2_stmt">
-    <p>Collect audit logs. Ensure that logging, per the enterprise’s audit log management process, has been enabled across enterprise assets.</p>
+    <p>Collect audit logs. Ensure that logging, per the enterprise’s audit log management process,
+     has been enabled across enterprise assets.</p>
    </part>
   </control>
   <control id="cisc-8.3">
    <title>Ensure Adequate Audit Log Storage</title>
    <prop name="label" value="CIS Safeguard 8.3"/>
    <prop name="sort-id" value="cisc-08.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-8.3_stmt">
-    <p>Ensure that logging destinations maintain adequate storage to comply with the enterprise’s audit log management process.</p>
+    <p>Ensure that logging destinations maintain adequate storage to comply with the enterprise’s
+     audit log management process.</p>
    </part>
   </control>
   <control id="cisc-8.4">
    <title>Standardize Time Synchronization</title>
    <prop name="label" value="CIS Safeguard 8.4"/>
    <prop name="sort-id" value="cisc-08.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-8.4_stmt">
-    <p>Standardize time synchronization. Configure at least two synchronized time sources across enterprise assets, where supported.</p>
+    <p>Standardize time synchronization. Configure at least two synchronized time sources across
+     enterprise assets, where supported.</p>
    </part>
   </control>
   <control id="cisc-8.5">
    <title>Collect Detailed Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.5"/>
    <prop name="sort-id" value="cisc-08.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-8.5_stmt">
-    <p>Configure detailed audit logging for enterprise assets containing sensitive data. Include event source, date, username, timestamp, source addresses, destination addresses, and other useful elements that could assist in a forensic investigation.</p>
+    <p>Configure detailed audit logging for enterprise assets containing sensitive data. Include
+     event source, date, username, timestamp, source addresses, destination addresses, and other
+     useful elements that could assist in a forensic investigation.</p>
    </part>
   </control>
   <control id="cisc-8.6">
    <title>Collect DNS Query Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.6"/>
    <prop name="sort-id" value="cisc-08.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-8.6_stmt">
@@ -1624,84 +1335,54 @@
    <title>Collect URL Request Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.7"/>
    <prop name="sort-id" value="cisc-08.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-8.7_stmt">
     <p>Collect URL request audit logs on enterprise assets, where appropriate and supported.</p>
    </part>
-  </control> 
+  </control>
   <control id="cisc-8.8">
    <title>Collect Command-Line Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.8"/>
    <prop name="sort-id" value="cisc-08.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-8.8_stmt">
-    <p>Collect command-line audit logs. Example implementations include collecting audit logs from PowerShell®, BASH™, and remote administrative terminals.</p>
+    <p>Collect command-line audit logs. Example implementations include collecting audit logs from
+     PowerShell®, BASH™, and remote administrative terminals.</p>
    </part>
   </control>
   <control id="cisc-8.9">
    <title>Centralize Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.9"/>
    <prop name="sort-id" value="cisc-08.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-8.9_stmt">
-    <p>Centralize, to the extent possible, audit log collection and retention across enterprise assets.</p>
+    <p>Centralize, to the extent possible, audit log collection and retention across enterprise
+     assets.</p>
    </part>
   </control>
   <control id="cisc-8.10">
    <title>Retain Audit Logs</title>
    <prop name="label" value="CIS Safeguard 8.10"/>
    <prop name="sort-id" value="cisc-08.10"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-8.9"/>
    <part name="statement" id="cisc-8.10_stmt">
@@ -1712,39 +1393,28 @@
    <title>Conduct Audit Log Reviews</title>
    <prop name="label" value="CIS Safeguard 8.11"/>
    <prop name="sort-id" value="cisc-08.11"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-8.11_stmt">
-    <p>Conduct reviews of audit logs to detect anomalies or abnormal events that could indicate a potential threat. Conduct reviews on a weekly, or more frequent, basis.</p>
+    <p>Conduct reviews of audit logs to detect anomalies or abnormal events that could indicate a
+     potential threat. Conduct reviews on a weekly, or more frequent, basis.</p>
    </part>
   </control>
   <control id="cisc-8.12">
    <title>Collect Service Provider Logs</title>
    <prop name="label" value="CIS Safeguard 8.12"/>
    <prop name="sort-id" value="cisc-08.12"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-15.1"/>
    <part name="statement" id="cisc-8.12_stmt">
-    <p>Collect service provider logs, where supported. Example implementations include collecting authentication and authorization events, data creation and disposal events, and user management events.</p>
+    <p>Collect service provider logs, where supported. Example implementations include collecting
+     authentication and authorization events, data creation and disposal events, and user management
+     events.</p>
    </part>
   </control>
  </control>
@@ -1753,142 +1423,108 @@
   <prop name="label" value="CIS Control 9"/>
   <prop name="sort-id" value="cisc-09"/>
   <part name="statement" id="cisc-9_stmt">
-   <p>Improve protections and detections of threats from email and web vectors, as these are opportunities for attackers to manipulate human behavior through direct engagement.</p>
+   <p>Improve protections and detections of threats from email and web vectors, as these are
+    opportunities for attackers to manipulate human behavior through direct engagement.</p>
   </part>
   <part name="guidance" id="cisc-9_gdn">
-   <p>Web browsers and email clients are very common points of entry for attackers because of their direct interaction with users inside an enterprise. Content can be crafted to entice or spoof users into disclosing credentials, providing sensitive data, or providing an open channel to allow attackers to gain access, thus increasing risk to the enterprise. Since email and web are the main means that users interact with external and untrusted users and environments, these are prime targets for both malicious code and social engineering. Additionally, as enterprises move to web-based email, or mobile email access, users no longer use traditional full-featured email clients, which provide embedded security controls like connection encryption, strong authentication, and phishing reporting buttons.</p>
+   <p>Web browsers and email clients are very common points of entry for attackers because of their
+    direct interaction with users inside an enterprise. Content can be crafted to entice or spoof
+    users into disclosing credentials, providing sensitive data, or providing an open channel to
+    allow attackers to gain access, thus increasing risk to the enterprise. Since email and web are
+    the main means that users interact with external and untrusted users and environments, these are
+    prime targets for both malicious code and social engineering. Additionally, as enterprises move
+    to web-based email, or mobile email access, users no longer use traditional full-featured email
+    clients, which provide embedded security controls like connection encryption, strong
+    authentication, and phishing reporting buttons.</p>
   </part>
   <control id="cisc-9.1">
    <title>Ensure Use of Only Fully Supported Browsers and Email Clients</title>
    <prop name="label" value="CIS Safeguard 9.1"/>
    <prop name="sort-id" value="cisc-09.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-9.1_stmt">
-    <p>Ensure only fully supported browsers and email clients are allowed to execute in the enterprise, only using the latest version of browsers and email clients provided through the vendor.</p>
+    <p>Ensure only fully supported browsers and email clients are allowed to execute in the
+     enterprise, only using the latest version of browsers and email clients provided through the
+     vendor.</p>
    </part>
   </control>
   <control id="cisc-9.2">
    <title>Use DNS Filtering Services</title>
    <prop name="label" value="CIS Safeguard 9.2"/>
    <prop name="sort-id" value="cisc-09.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-9.2_stmt">
-    <p>Use DNS filtering services on all enterprise assets to block access to known malicious domains.</p>
+    <p>Use DNS filtering services on all enterprise assets to block access to known malicious
+     domains.</p>
    </part>
   </control>
   <control id="cisc-9.3">
    <title>Maintain and Enforce Network-Based URL Filters</title>
    <prop name="label" value="CIS Safeguard 9.3"/>
    <prop name="sort-id" value="cisc-09.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-9.3_stmt">
-    <p>Enforce and update network-based URL filters to limit an enterprise asset from connecting to potentially malicious or unapproved websites. Example implementations include category-based filtering, reputation-based filtering, or through the use of block lists. Enforce filters for all enterprise assets.</p>
+    <p>Enforce and update network-based URL filters to limit an enterprise asset from connecting to
+     potentially malicious or unapproved websites. Example implementations include category-based
+     filtering, reputation-based filtering, or through the use of block lists. Enforce filters for
+     all enterprise assets.</p>
    </part>
   </control>
   <control id="cisc-9.4">
    <title>Restrict Unnecessary or Unauthorized Browser and Email Client Extensions</title>
    <prop name="label" value="CIS Safeguard 9.4"/>
    <prop name="sort-id" value="cisc-09.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-9.4_stmt">
-    <p>Restrict, either through uninstalling or disabling, any unauthorized or unnecessary browser or email client plugins, extensions, and add-on applications.</p>
+    <p>Restrict, either through uninstalling or disabling, any unauthorized or unnecessary browser
+     or email client plugins, extensions, and add-on applications.</p>
    </part>
   </control>
   <control id="cisc-9.5">
    <title>Implement DMARC</title>
    <prop name="label" value="CIS Safeguard 9.5"/>
    <prop name="sort-id" value="cisc-09.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-9.5_stmt">
-    <p>To lower the chance of spoofed or modified emails from valid domains, implement DMARC policy and verification, starting with implementing the Sender Policy Framework (SPF) and the DomainKeys Identified Mail (DKIM) standards.</p>
+    <p>To lower the chance of spoofed or modified emails from valid domains, implement DMARC policy
+     and verification, starting with implementing the Sender Policy Framework (SPF) and the
+     DomainKeys Identified Mail (DKIM) standards.</p>
    </part>
   </control>
   <control id="cisc-9.6">
    <title>Block Unnecessary File Types</title>
    <prop name="label" value="CIS Safeguard 9.6"/>
    <prop name="sort-id" value="cisc-09.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-9.6_stmt">
@@ -1899,53 +1535,49 @@
    <title>Deploy and Maintain Email Server Anti-Malware Protections</title>
    <prop name="label" value="CIS Safeguard 9.7"/>
    <prop name="sort-id" value="cisc-09.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-9.7_stmt">
-    <p>Deploy and maintain email server anti-malware protections, such as attachment scanning and/or sandboxing.</p>
+    <p>Deploy and maintain email server anti-malware protections, such as attachment scanning and/or
+     sandboxing.</p>
    </part>
-  </control> 
+  </control>
  </control>
  <control id="cisc-10">
   <title>Malware Defenses</title>
   <prop name="label" value="CIS Control 10"/>
   <prop name="sort-id" value="cisc-10"/>
   <part name="statement" id="cisc-10_stmt">
-   <p>Prevent or control the installation, spread, and execution of malicious applications, code, or scripts on enterprise assets.</p>
+   <p>Prevent or control the installation, spread, and execution of malicious applications, code, or
+    scripts on enterprise assets.</p>
   </part>
   <part name="guidance" id="cisc-10_gdn">
-   <p>Malicious software (sometimes categorized as viruses or Trojans) is an integral and dangerous aspect of internet threats. They can have many purposes, from capturing credentials, stealing data, identifying other targets within the network, and encrypting or destroying data. Malware is ever-evolving and adaptive, as modern variants leverage machine learning techniques.</p>
-   <p>Malware enters an enterprise through vulnerabilities within the enterprise on end-user devices, email attachments, webpages, cloud services, mobile devices, and removable media. Malware often relies on insecure end-user behavior, such as clicking links, opening attachments, installing software or profiles, or inserting Universal Serial Bus (USB) flash drives. Modern malware is designed to avoid, deceive, or disable defenses.</p>
-   <p>Malware defenses must be able to operate in this dynamic environment through automation, timely and rapid updating, and integration with other processes like vulnerability management and incident response. They must be deployed at all possible entry points and enterprise assets to detect, prevent spread, or control the execution of malicious software or code.</p>
+   <p>Malicious software (sometimes categorized as viruses or Trojans) is an integral and dangerous
+    aspect of internet threats. They can have many purposes, from capturing credentials, stealing
+    data, identifying other targets within the network, and encrypting or destroying data. Malware
+    is ever-evolving and adaptive, as modern variants leverage machine learning techniques.</p>
+   <p>Malware enters an enterprise through vulnerabilities within the enterprise on end-user
+    devices, email attachments, webpages, cloud services, mobile devices, and removable media.
+    Malware often relies on insecure end-user behavior, such as clicking links, opening attachments,
+    installing software or profiles, or inserting Universal Serial Bus (USB) flash drives. Modern
+    malware is designed to avoid, deceive, or disable defenses.</p>
+   <p>Malware defenses must be able to operate in this dynamic environment through automation,
+    timely and rapid updating, and integration with other processes like vulnerability management
+    and incident response. They must be deployed at all possible entry points and enterprise assets
+    to detect, prevent spread, or control the execution of malicious software or code.</p>
   </part>
   <control id="cisc-10.1">
    <title>Deploy and Maintain Anti-Malware Software</title>
    <prop name="label" value="CIS Safeguard 10.1"/>
    <prop name="sort-id" value="cisc-10.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
@@ -1957,21 +1589,11 @@
    <title>Configure Automatic Anti-Malware Signature Updates</title>
    <prop name="label" value="CIS Safeguard 10.2"/>
    <prop name="sort-id" value="cisc-10.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-10.1"/>
    <part name="statement" id="cisc-10.2_stmt">
     <p>Configure automatic updates for anti-malware signature files on all enterprise assets.</p>
@@ -1981,21 +1603,11 @@
    <title>Disable Autorun and Autoplay for Removable Media</title>
    <prop name="label" value="CIS Safeguard 10.3"/>
    <prop name="sort-id" value="cisc-10.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-10.3_stmt">
@@ -2006,18 +1618,10 @@
    <title>Configure Automatic Anti-Malware Scanning of Removable Media</title>
    <prop name="label" value="CIS Safeguard 10.4"/>
    <prop name="sort-id" value="cisc-10.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-10.1"/>
    <part name="statement" id="cisc-10.4_stmt">
@@ -2028,40 +1632,26 @@
    <title>Enable Anti-Exploitation Features</title>
    <prop name="label" value="CIS Safeguard 10.5"/>
    <prop name="sort-id" value="cisc-10.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-10.5_stmt">
-    <p>Enable anti-exploitation features on enterprise assets and software, where possible, such as Microsoft® Data Execution Prevention (DEP), Windows® Defender Exploit Guard (WDEG), or Apple® System Integrity Protection (SIP) and Gatekeeper™.</p>
+    <p>Enable anti-exploitation features on enterprise assets and software, where possible, such as
+     Microsoft® Data Execution Prevention (DEP), Windows® Defender Exploit Guard (WDEG), or Apple®
+     System Integrity Protection (SIP) and Gatekeeper™.</p>
    </part>
   </control>
   <control id="cisc-10.6">
    <title>Centrally Manage Anti-Malware Software</title>
    <prop name="label" value="CIS Safeguard 10.6"/>
    <prop name="sort-id" value="cisc-10.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-10.1"/>
@@ -2073,277 +1663,235 @@
    <title>Use Behavior-Based Anti-Malware Software</title>
    <prop name="label" value="CIS Safeguard 10.7"/>
    <prop name="sort-id" value="cisc-10.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-10.7_stmt">
     <p>Use behavior-based anti-malware software.</p>
    </part>
-  </control> 
+  </control>
  </control>
  <control id="cisc-11">
   <title>Data Recovery</title>
   <prop name="label" value="CIS Control 11"/>
   <prop name="sort-id" value="cisc-11"/>
   <part name="statement" id="cisc-11_stmt">
-   <p>Establish and maintain data recovery practices sufficient to restore in-scope enterprise assets to a pre-incident and trusted state.</p>
+   <p>Establish and maintain data recovery practices sufficient to restore in-scope enterprise
+    assets to a pre-incident and trusted state.</p>
   </part>
   <part name="guidance" id="cisc-11_gdn">
-   <p>In the cybersecurity triad – Confidentiality, Integrity, and Availability (CIA) – the availability of data is, in some cases, more critical than its confidentiality. Enterprises need many types of data to make business decisions, and when that data is not available or is untrusted, then it could impact the enterprise. An easy example is weather information to a transportation enterprise.</p>
-   <p>When attackers compromise assets, they make changes to configurations, add accounts, and often add software or scripts. These changes are not always easy to identify, as attackers might have corrupted or replaced trusted applications with malicious versions, or the changes might appear to be standard-looking account names. Configuration changes can include adding or changing registry entries, opening ports, turning off security services, deleting logs, or other malicious actions that make a system insecure. These actions do not have to be malicious; human error can cause each of these as well. Therefore, it is important to have an ability to have recent backups or mirrors to recover enterprise assets and data back to a known trusted state.</p>
-   <p>There has been an exponential rise in ransomware over the last few years. It is not a new threat, though it has become more commercialized and organized as a reliable method for attackers to make money. If an attacker encrypts an enterprise’s data and demands ransom for its restoration, having a recent backup to recover to a known, trusted state can be helpful. However, as ransomware has evolved, it has also become an extortion technique, where data is exfiltrated before being encrypted, and the attacker asks for payment to restore the enterprise’s data, as well as to keep it from being sold or publicized. In this case, restoration would only solve the issue of restoring systems to a trusted state and continuing operations. Leveraging the guidance within the CIS Controls will help reduce the risk of ransomware through improved cyber hygiene, as attackers usually use older or basic exploits on insecure systems.</p>
+   <p>In the cybersecurity triad – Confidentiality, Integrity, and Availability (CIA) – the
+    availability of data is, in some cases, more critical than its confidentiality. Enterprises need
+    many types of data to make business decisions, and when that data is not available or is
+    untrusted, then it could impact the enterprise. An easy example is weather information to a
+    transportation enterprise.</p>
+   <p>When attackers compromise assets, they make changes to configurations, add accounts, and often
+    add software or scripts. These changes are not always easy to identify, as attackers might have
+    corrupted or replaced trusted applications with malicious versions, or the changes might appear
+    to be standard-looking account names. Configuration changes can include adding or changing
+    registry entries, opening ports, turning off security services, deleting logs, or other
+    malicious actions that make a system insecure. These actions do not have to be malicious; human
+    error can cause each of these as well. Therefore, it is important to have an ability to have
+    recent backups or mirrors to recover enterprise assets and data back to a known trusted
+    state.</p>
+   <p>There has been an exponential rise in ransomware over the last few years. It is not a new
+    threat, though it has become more commercialized and organized as a reliable method for
+    attackers to make money. If an attacker encrypts an enterprise’s data and demands ransom for its
+    restoration, having a recent backup to recover to a known, trusted state can be helpful.
+    However, as ransomware has evolved, it has also become an extortion technique, where data is
+    exfiltrated before being encrypted, and the attacker asks for payment to restore the
+    enterprise’s data, as well as to keep it from being sold or publicized. In this case,
+    restoration would only solve the issue of restoring systems to a trusted state and continuing
+    operations. Leveraging the guidance within the CIS Controls will help reduce the risk of
+    ransomware through improved cyber hygiene, as attackers usually use older or basic exploits on
+    insecure systems.</p>
   </part>
   <control id="cisc-11.1">
    <title>Establish and Maintain a Data Recovery Process</title>
    <prop name="label" value="CIS Safeguard 11.1"/>
    <prop name="sort-id" value="cisc-11.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recovery"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recovery"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-11.1_stmt">
-    <p>Establish and maintain a data recovery process. In the process, address the scope of data recovery activities, recovery prioritization, and the security of backup data. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a data recovery process. In the process, address the scope of data
+     recovery activities, recovery prioritization, and the security of backup data. Review and
+     update documentation annually, or when significant enterprise changes occur that could impact
+     this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-11.2">
    <title>Perform Automated Backups</title>
    <prop name="label" value="CIS Safeguard 11.2"/>
    <prop name="sort-id" value="cisc-11.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recovery"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recovery"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-11.2_stmt">
-    <p>Perform automated backups of in-scope enterprise assets. Run backups weekly, or more frequently, based on the sensitivity of the data.</p>
+    <p>Perform automated backups of in-scope enterprise assets. Run backups weekly, or more
+     frequently, based on the sensitivity of the data.</p>
    </part>
   </control>
   <control id="cisc-11.3">
    <title>Protect Recovery Data</title>
    <prop name="label" value="CIS Safeguard 11.3"/>
    <prop name="sort-id" value="cisc-11.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-11.3_stmt">
-    <p>Protect recovery data with equivalent controls to the original data. Reference encryption or data separation, based on requirements.</p>
+    <p>Protect recovery data with equivalent controls to the original data. Reference encryption or
+     data separation, based on requirements.</p>
    </part>
   </control>
   <control id="cisc-11.4">
    <title>Establish and Maintain an Isolated Instance of Recovery Data</title>
    <prop name="label" value="CIS Safeguard 11.4"/>
    <prop name="sort-id" value="cisc-11.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recovery"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recovery"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <part name="statement" id="cisc-11.4_stmt">
-    <p>Establish and maintain an isolated instance of recovery data. Example implementations include, version controlling backup destinations through offline, cloud, or off-site systems or services.</p>
+    <p>Establish and maintain an isolated instance of recovery data. Example implementations
+     include, version controlling backup destinations through offline, cloud, or off-site systems or
+     services.</p>
    </part>
   </control>
   <control id="cisc-11.5">
    <title>Test Data Recovery</title>
    <prop name="label" value="CIS Safeguard 11.5"/>
    <prop name="sort-id" value="cisc-11.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recover"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recover"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-11.5_stmt">
-    <p>Test backup recovery quarterly, or more frequently, for a sampling of in-scope enterprise assets.</p>
+    <p>Test backup recovery quarterly, or more frequently, for a sampling of in-scope enterprise
+     assets.</p>
    </part>
-  </control>  
+  </control>
  </control>
  <control id="cisc-12">
   <title>Network Infrastructure Management</title>
   <prop name="label" value="CIS Control 12"/>
   <prop name="sort-id" value="cisc-12"/>
   <part name="statement" id="cisc-12_stmt">
-   <p>Establish, implement, and actively manage (track, report, correct) network devices, in order to prevent attackers from exploiting vulnerable network services and access points.</p>
+   <p>Establish, implement, and actively manage (track, report, correct) network devices, in order
+    to prevent attackers from exploiting vulnerable network services and access points.</p>
   </part>
   <part name="guidance" id="cisc-12_gdn">
-   <p>Secure network infrastructure is an essential defense against attacks. This includes an appropriate security architecture, addressing vulnerabilities that are, often times, introduced with default settings, monitoring for changes, and reassessment of current configurations. Network infrastructure includes devices such as physical and virtualized gateways, firewalls, wireless access points, routers, and switches.</p>
-   <p>Default configurations for network devices are geared for ease-of-deployment and ease-of-use – not security. Potential default vulnerabilities include open services and ports, default accounts and passwords (including service accounts), support for older vulnerable protocols, and pre-installation of unneeded software. Attackers search for vulnerable default settings, gaps or inconsistencies in firewall rule sets, routers, and switches and use those holes to penetrate defenses. They exploit flaws in these devices to gain access to networks, redirect traffic on a network, and intercept data while in transmission.</p>
-   <p>Network security is a constantly changing environment that necessitates regular re-evaluation of architecture diagrams, configurations, access controls, and allowed traffic flows. Attackers take advantage of network device configurations becoming less secure over time as users demand exceptions for specific business needs. Sometimes the exceptions are deployed, but not removed when they are no longer applicable to the business’s needs. In some cases, the security risk of an exception is neither properly analyzed nor measured against the associated business need and can change over time.</p>
+   <p>Secure network infrastructure is an essential defense against attacks. This includes an
+    appropriate security architecture, addressing vulnerabilities that are, often times, introduced
+    with default settings, monitoring for changes, and reassessment of current configurations.
+    Network infrastructure includes devices such as physical and virtualized gateways, firewalls,
+    wireless access points, routers, and switches.</p>
+   <p>Default configurations for network devices are geared for ease-of-deployment and ease-of-use –
+    not security. Potential default vulnerabilities include open services and ports, default
+    accounts and passwords (including service accounts), support for older vulnerable protocols, and
+    pre-installation of unneeded software. Attackers search for vulnerable default settings, gaps or
+    inconsistencies in firewall rule sets, routers, and switches and use those holes to penetrate
+    defenses. They exploit flaws in these devices to gain access to networks, redirect traffic on a
+    network, and intercept data while in transmission.</p>
+   <p>Network security is a constantly changing environment that necessitates regular re-evaluation
+    of architecture diagrams, configurations, access controls, and allowed traffic flows. Attackers
+    take advantage of network device configurations becoming less secure over time as users demand
+    exceptions for specific business needs. Sometimes the exceptions are deployed, but not removed
+    when they are no longer applicable to the business’s needs. In some cases, the security risk of
+    an exception is neither properly analyzed nor measured against the associated business need and
+    can change over time.</p>
   </part>
   <control id="cisc-12.1">
    <title>Ensure Network Infrastructure is Up-to-Date</title>
    <prop name="label" value="CIS Safeguard 12.1"/>
    <prop name="sort-id" value="cisc-12.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-12.1_stmt">
-    <p>Ensure network infrastructure is kept up-to-date. Example implementations include running the latest stable release of software and/or using currently supported network-as-a-service (NaaS) offerings. Review software versions monthly, or more frequently, to verify software support.</p>
+    <p>Ensure network infrastructure is kept up-to-date. Example implementations include running the
+     latest stable release of software and/or using currently supported network-as-a-service (NaaS)
+     offerings. Review software versions monthly, or more frequently, to verify software
+     support.</p>
    </part>
   </control>
   <control id="cisc-12.2">
    <title>Establish and Maintain a Secure Network Architecture</title>
    <prop name="label" value="CIS Safeguard 12.2"/>
    <prop name="sort-id" value="cisc-12.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-12.2_stmt">
-    <p>Establish and maintain a secure network architecture. A secure network architecture must address segmentation, least privilege, and availability, at a minimum.</p>
+    <p>Establish and maintain a secure network architecture. A secure network architecture must
+     address segmentation, least privilege, and availability, at a minimum.</p>
    </part>
   </control>
   <control id="cisc-12.3">
    <title>Securely Manage Network Infrastructure</title>
    <prop name="label" value="CIS Safeguard 12.3"/>
    <prop name="sort-id" value="cisc-12.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.2"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-12.3_stmt">
-    <p>Securely manage network infrastructure. Example implementations include version-controlled-infrastructure-as-code, and the use of secure network protocols, such as SSH and HTTPS.</p>
+    <p>Securely manage network infrastructure. Example implementations include
+     version-controlled-infrastructure-as-code, and the use of secure network protocols, such as SSH
+     and HTTPS.</p>
    </part>
   </control>
   <control id="cisc-12.4">
    <title>Establish and Maintain Architecture Diagram(s)</title>
    <prop name="label" value="CIS Safeguard 12.4"/>
    <prop name="sort-id" value="cisc-12.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-12.4_stmt">
-    <p>Establish and maintain architecture diagram(s) and/or other network system documentation. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain architecture diagram(s) and/or other network system documentation.
+     Review and update documentation annually, or when significant enterprise changes occur that
+     could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-12.5">
    <title>Centralize Network Authentication, Authorization, and Auditing (AAA)</title>
    <prop name="label" value="CIS Safeguard 12.5"/>
    <prop name="sort-id" value="cisc-12.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-12.5_stmt">
     <p>Centralize network AAA</p>
@@ -2353,64 +1901,48 @@
    <title>Use of Secure Network Management and Communication Protocols</title>
    <prop name="label" value="CIS Safeguard 12.6"/>
    <prop name="sort-id" value="cisc-12.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.2"/>
    <link rel="dependency" href="cisc-12.2"/>
    <part name="statement" id="cisc-12.6_stmt">
-    <p>Use secure network management and communication protocols (e.g., 802.1X, Wi-Fi Protected Access 2 (WPA2) Enterprise or greater).</p>
+    <p>Use secure network management and communication protocols (e.g., 802.1X, Wi-Fi Protected
+     Access 2 (WPA2) Enterprise or greater).</p>
    </part>
   </control>
   <control id="cisc-12.7">
-   <title>Ensure Remote Devices Utilize a VPN and are Connecting to an Enterprise’s AAA Infrastructure</title>
+   <title>Ensure Remote Devices Utilize a VPN and are Connecting to an Enterprise’s AAA
+    Infrastructure</title>
    <prop name="label" value="CIS Safeguard 12.7"/>
    <prop name="sort-id" value="cisc-12.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <link rel="dependency" href="cisc-12.5"/>
    <part name="statement" id="cisc-12.7_stmt">
-    <p>Require users to authenticate to enterprise-managed VPN and authentication services prior to accessing enterprise resources on end-user devices.</p>
+    <p>Require users to authenticate to enterprise-managed VPN and authentication services prior to
+     accessing enterprise resources on end-user devices.</p>
    </part>
   </control>
   <control id="cisc-12.8">
    <title>Establish and Maintain Dedicated Computing Resources for All Administrative Work</title>
    <prop name="label" value="CIS Safeguard 12.8"/>
    <prop name="sort-id" value="cisc-12.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.2"/>
    <part name="statement" id="cisc-12.8_stmt">
-    <p>Establish and maintain dedicated computing resources, either physically or logically separated, for all administrative tasks or tasks requiring administrative access. The computing resources should be segmented from the enterprise’s primary network and not be allowed internet access.</p>
+    <p>Establish and maintain dedicated computing resources, either physically or logically
+     separated, for all administrative tasks or tasks requiring administrative access. The computing
+     resources should be segmented from the enterprise’s primary network and not be allowed internet
+     access.</p>
    </part>
   </control>
  </control>
@@ -2419,96 +1951,94 @@
   <prop name="label" value="CIS Control 13"/>
   <prop name="sort-id" value="cisc-13"/>
   <part name="statement" id="cisc-13_stmt">
-   <p>Operate processes and tooling to establish and maintain comprehensive network monitoring and defense against security threats across the enterprise’s network infrastructure and user base.</p>
+   <p>Operate processes and tooling to establish and maintain comprehensive network monitoring and
+    defense against security threats across the enterprise’s network infrastructure and user
+    base.</p>
   </part>
   <part name="guidance" id="cisc-13_gdn">
-   <p>We cannot rely on network defenses to be perfect. Adversaries continue to evolve and mature, as they share, or sell, information among their community on exploits and bypasses to security controls. Even if security tools work “as advertised,” it takes an understanding of the enterprise risk posture to configure, tune, and log them to be effective. Often, misconfigurations due to human error or lack of knowledge of tool capabilities give enterprises a false sense of security.</p>
-   <p>Security tools can only be effective if they are supporting a process of continuous monitoring that allows staff the ability to be alerted and respond to security incidents quickly. Enterprises that adopt a purely technology-driven approach will also experience more false positives, due to their over-reliance on alerts from tools. Identifying and responding to these threats requires visibility into all threat vectors of the infrastructure and leveraging humans in the process of detection, analysis, and response. It is critical for large or heavily targeted enterprises to have a security operations capability to prevent, detect, and quickly respond to cyber threats before they can impact the enterprise. This process will generate activity reports and metrics that will help enhance security policies, and support regulatory compliance for many enterprises.</p>
-   <p>As we have seen many times in the press, enterprises have been compromised for weeks, months, or years before discovery. The primary benefit of having comprehensive situational awareness is to increase the speed of detection and response. This is critical to respond quickly when malware is discovered, credentials are stolen, or when sensitive data is compromised to reduce impact to the enterprise.</p>
-   <p>Through good situational awareness (i.e., security operations), enterprises will identify and catalog Tactics, Techniques, and Procedures (TTPs) of attackers, including their IOCs that will help the enterprise become more proactive in identifying future threats or incidents. Recovery can be achieved faster when the response has access to complete information about the environment and enterprise structure to develop efficient response strategies.</p>
+   <p>We cannot rely on network defenses to be perfect. Adversaries continue to evolve and mature,
+    as they share, or sell, information among their community on exploits and bypasses to security
+    controls. Even if security tools work “as advertised,” it takes an understanding of the
+    enterprise risk posture to configure, tune, and log them to be effective. Often,
+    misconfigurations due to human error or lack of knowledge of tool capabilities give enterprises
+    a false sense of security.</p>
+   <p>Security tools can only be effective if they are supporting a process of continuous monitoring
+    that allows staff the ability to be alerted and respond to security incidents quickly.
+    Enterprises that adopt a purely technology-driven approach will also experience more false
+    positives, due to their over-reliance on alerts from tools. Identifying and responding to these
+    threats requires visibility into all threat vectors of the infrastructure and leveraging humans
+    in the process of detection, analysis, and response. It is critical for large or heavily
+    targeted enterprises to have a security operations capability to prevent, detect, and quickly
+    respond to cyber threats before they can impact the enterprise. This process will generate
+    activity reports and metrics that will help enhance security policies, and support regulatory
+    compliance for many enterprises.</p>
+   <p>As we have seen many times in the press, enterprises have been compromised for weeks, months,
+    or years before discovery. The primary benefit of having comprehensive situational awareness is
+    to increase the speed of detection and response. This is critical to respond quickly when
+    malware is discovered, credentials are stolen, or when sensitive data is compromised to reduce
+    impact to the enterprise.</p>
+   <p>Through good situational awareness (i.e., security operations), enterprises will identify and
+    catalog Tactics, Techniques, and Procedures (TTPs) of attackers, including their IOCs that will
+    help the enterprise become more proactive in identifying future threats or incidents. Recovery
+    can be achieved faster when the response has access to complete information about the
+    environment and enterprise structure to develop efficient response strategies.</p>
   </part>
   <control id="cisc-13.1">
    <title>Centralize Security Event Alerting</title>
    <prop name="label" value="CIS Safeguard 13.1"/>
    <prop name="sort-id" value="cisc-13.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-13.1_stmt">
-    <p>Centralize security event alerting across enterprise assets for log correlation and analysis. Best practice implementation requires the use of a SIEM, which includes vendor-defined event correlation alerts. A log analytics platform configured with security-relevant correlation alerts also satisfies this Safeguard.</p>
+    <p>Centralize security event alerting across enterprise assets for log correlation and analysis.
+     Best practice implementation requires the use of a SIEM, which includes vendor-defined event
+     correlation alerts. A log analytics platform configured with security-relevant correlation
+     alerts also satisfies this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-13.2">
    <title>Deploy a Host-Based Intrusion Detection Solution</title>
    <prop name="label" value="CIS Safeguard 13.2"/>
    <prop name="sort-id" value="cisc-13.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-13.2_stmt">
-    <p>Deploy a host-based intrusion detection solution on enterprise assets, where appropriate and/or supported.</p>
+    <p>Deploy a host-based intrusion detection solution on enterprise assets, where appropriate
+     and/or supported.</p>
    </part>
   </control>
   <control id="cisc-13.3">
    <title>Deploy a Network Intrusion Detection Solution</title>
    <prop name="label" value="CIS Safeguard 13.3"/>
    <prop name="sort-id" value="cisc-13.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-13.3_stmt">
-    <p>Deploy a network intrusion detection solution on enterprise assets, where appropriate. Example implementations include the use of a Network Intrusion Detection System (NIDS) or equivalent cloud service provider (CSP) service.</p>
+    <p>Deploy a network intrusion detection solution on enterprise assets, where appropriate.
+     Example implementations include the use of a Network Intrusion Detection System (NIDS) or
+     equivalent cloud service provider (CSP) service.</p>
    </part>
   </control>
   <control id="cisc-13.4">
    <title>Perform Traffic Filtering Between Network Segments</title>
    <prop name="label" value="CIS Safeguard 13.4"/>
    <prop name="sort-id" value="cisc-13.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-13.4_stmt">
     <p>Perform traffic filtering between network segments, where appropriate.</p>
    </part>
@@ -2517,136 +2047,100 @@
    <title>Manage Access Control for Remote Assets</title>
    <prop name="label" value="CIS Safeguard 13.5"/>
    <prop name="sort-id" value="cisc-13.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-6.6"/>
    <part name="statement" id="cisc-13.5_stmt">
-    <p>Manage access control for assets remotely connecting to enterprise resources. Determine amount of access to enterprise resources based on: up-to-date anti-malware software installed, configuration compliance with the enterprise’s secure configuration process, and ensuring the operating system and applications are up-to-date.</p>
+    <p>Manage access control for assets remotely connecting to enterprise resources. Determine
+     amount of access to enterprise resources based on: up-to-date anti-malware software installed,
+     configuration compliance with the enterprise’s secure configuration process, and ensuring the
+     operating system and applications are up-to-date.</p>
    </part>
   </control>
   <control id="cisc-13.6">
    <title>Collect Network Traffic Flow Logs</title>
    <prop name="label" value="CIS Safeguard 13.6"/>
    <prop name="sort-id" value="cisc-13.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-4.2"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-13.6_stmt">
-    <p>Collect network traffic flow logs and/or network traffic to review and alert upon from network devices.</p>
+    <p>Collect network traffic flow logs and/or network traffic to review and alert upon from
+     network devices.</p>
    </part>
   </control>
   <control id="cisc-13.7">
    <title>Deploy a Host-Based Intrusion Prevention Solution</title>
    <prop name="label" value="CIS Safeguard 13.7"/>
    <prop name="sort-id" value="cisc-13.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-13.7_stmt">
-    <p>Deploy a host-based intrusion prevention solution on enterprise assets, where appropriate and/or supported. Example implementations include use of an Endpoint Detection and Response (EDR) client or host-based IPS agent.</p>
+    <p>Deploy a host-based intrusion prevention solution on enterprise assets, where appropriate
+     and/or supported. Example implementations include use of an Endpoint Detection and Response
+     (EDR) client or host-based IPS agent.</p>
    </part>
   </control>
   <control id="cisc-13.8">
    <title>Deploy a Network Intrusion Prevention Solutions</title>
    <prop name="label" value="CIS Safeguard 13.8"/>
    <prop name="sort-id" value="cisc-13.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-12.4"/>
    <part name="statement" id="cisc-13.8_stmt">
-    <p>Deploy a network intrusion prevention solution, where appropriate. Example implementations include the use of a Network Intrusion Prevention System (NIPS) or equivalent CSP service.</p>
+    <p>Deploy a network intrusion prevention solution, where appropriate. Example implementations
+     include the use of a Network Intrusion Prevention System (NIPS) or equivalent CSP service.</p>
    </part>
   </control>
   <control id="cisc-13.9">
    <title>Deploy Port-Level Access Control</title>
    <prop name="label" value="CIS Safeguard 13.9"/>
    <prop name="sort-id" value="cisc-13.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="devices"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="devices"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <part name="statement" id="cisc-13.9_stmt">
-    <p>Deploy port-level access control. Port-level access control utilizes 802.1x, or similar network access control protocols, such as certificates, and may incorporate user and/or device authentication.</p>
+    <p>Deploy port-level access control. Port-level access control utilizes 802.1x, or similar
+     network access control protocols, such as certificates, and may incorporate user and/or device
+     authentication.</p>
    </part>
   </control>
   <control id="cisc-13.10">
    <title>Perform Application Layer Filtering</title>
    <prop name="label" value="CIS Safeguard 13.10"/>
    <prop name="sort-id" value="cisc-13.10"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-1.1"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-13.10_stmt">
-    <p>Perform application layer filtering. Example implementations include a filtering proxy, application layer firewall, or gateway.</p>
+    <p>Perform application layer filtering. Example implementations include a filtering proxy,
+     application layer firewall, or gateway.</p>
    </part>
   </control>
   <control id="cisc-13.11">
    <title>Tune Security Event Alerting Thresholds</title>
    <prop name="label" value="CIS Safeguard 13.11"/>
    <prop name="sort-id" value="cisc-13.11"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-13.1"/>
    <part name="statement" id="cisc-13.11_stmt">
     <p>Tune security event alerting thresholds monthly, or more frequently.</p>
@@ -2658,378 +2152,318 @@
   <prop name="label" value="CIS Control 14"/>
   <prop name="sort-id" value="cisc-14"/>
   <part name="statement" id="cisc-14_stmt">
-   <p>Establish and maintain a security awareness program to influence behavior among the workforce to be security conscious and properly skilled to reduce cybersecurity risks to the enterprise.</p>
+   <p>Establish and maintain a security awareness program to influence behavior among the workforce
+    to be security conscious and properly skilled to reduce cybersecurity risks to the
+    enterprise.</p>
   </part>
   <part name="guidance" id="cisc-14_gdn">
-   <p>The actions of people play a critical part in the success or failure of an enterprise’s security program. It is easier for an attacker to entice a user to click a link or open an email attachment to install malware in order to get into an enterprise, than to find a network exploit to do it directly.</p>
-   <p>Users themselves, both intentionally and unintentionally, can cause incidents as a result of mishandling sensitive data, sending an email with sensitive data to the wrong recipient, losing a portable end-user device, using weak passwords, or using the same password they use on public sites.</p>
-   <p>No security program can effectively address cyber risk without a means to address this fundamental human vulnerability. Users at every level of the enterprise have different risks. For example: executives manage more sensitive data; system administrators have the ability to control access to systems and applications; and users in finance, human resources, and contracts all have access to different types of sensitive data that can make them targets.</p>
-   <p>The training should be updated regularly. This will increase the culture of security and discourage risky workarounds.</p>
+   <p>The actions of people play a critical part in the success or failure of an enterprise’s
+    security program. It is easier for an attacker to entice a user to click a link or open an email
+    attachment to install malware in order to get into an enterprise, than to find a network exploit
+    to do it directly.</p>
+   <p>Users themselves, both intentionally and unintentionally, can cause incidents as a result of
+    mishandling sensitive data, sending an email with sensitive data to the wrong recipient, losing
+    a portable end-user device, using weak passwords, or using the same password they use on public
+    sites.</p>
+   <p>No security program can effectively address cyber risk without a means to address this
+    fundamental human vulnerability. Users at every level of the enterprise have different risks.
+    For example: executives manage more sensitive data; system administrators have the ability to
+    control access to systems and applications; and users in finance, human resources, and contracts
+    all have access to different types of sensitive data that can make them targets.</p>
+   <p>The training should be updated regularly. This will increase the culture of security and
+    discourage risky workarounds.</p>
   </part>
   <control id="cisc-14.1">
    <title>Establish and Maintain a Security Awareness Program</title>
    <prop name="label" value="CIS Safeguard 14.1"/>
    <prop name="sort-id" value="cisc-14.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.1_stmt">
-    <p>Establish and maintain a security awareness program. The purpose of a security awareness program is to educate the enterprise’s workforce on how to interact with enterprise assets and data in a secure manner. Conduct training at hire and, at a minimum, annually. Review and update content annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a security awareness program. The purpose of a security awareness
+     program is to educate the enterprise’s workforce on how to interact with enterprise assets and
+     data in a secure manner. Conduct training at hire and, at a minimum, annually. Review and
+     update content annually, or when significant enterprise changes occur that could impact this
+     Safeguard.</p>
    </part>
   </control>
   <control id="cisc-14.2">
    <title>Train Workforce Members to Recognize Social Engineering Attacks</title>
    <prop name="label" value="CIS Safeguard 14.2"/>
    <prop name="sort-id" value="cisc-14.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.2_stmt">
-    <p>Train workforce members to recognize social engineering attacks, such as phishing, pre-texting, and tailgating.</p>
+    <p>Train workforce members to recognize social engineering attacks, such as phishing,
+     pre-texting, and tailgating.</p>
    </part>
   </control>
   <control id="cisc-14.3">
    <title>Train Workforce Members on Authentication Best Practices</title>
    <prop name="label" value="CIS Safeguard 14.3"/>
    <prop name="sort-id" value="cisc-14.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.3_stmt">
-    <p>Train workforce members on authentication best practices. Example topics include MFA, password composition, and credential management.</p>
+    <p>Train workforce members on authentication best practices. Example topics include MFA,
+     password composition, and credential management.</p>
    </part>
   </control>
   <control id="cisc-14.4">
    <title>Train Workforce on Data Handling Best Practices</title>
    <prop name="label" value="CIS Safeguard 14.4"/>
    <prop name="sort-id" value="cisc-14.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.4_stmt">
-    <p>Train workforce members on how to identify and properly store, transfer, archive, and destroy sensitive data. This also includes training workforce members on clear screen and desk best practices, such as locking their screen when they step away from their enterprise asset, erasing physical and virtual whiteboards at the end of meetings, and storing data and assets securely.</p>
+    <p>Train workforce members on how to identify and properly store, transfer, archive, and destroy
+     sensitive data. This also includes training workforce members on clear screen and desk best
+     practices, such as locking their screen when they step away from their enterprise asset,
+     erasing physical and virtual whiteboards at the end of meetings, and storing data and assets
+     securely.</p>
    </part>
   </control>
   <control id="cisc-14.5">
    <title>Train Workforce Members on Causes of Unintentional Data Exposure</title>
    <prop name="label" value="CIS Safeguard 14.5"/>
    <prop name="sort-id" value="cisc-14.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.5_stmt">
-    <p>Train workforce members to be aware of causes for unintentional data exposure. Example topics include mis-delivery of sensitive data, losing a portable end-user device, or publishing data to unintended audiences.</p>
+    <p>Train workforce members to be aware of causes for unintentional data exposure. Example topics
+     include mis-delivery of sensitive data, losing a portable end-user device, or publishing data
+     to unintended audiences.</p>
    </part>
   </control>
   <control id="cisc-14.6">
    <title>Train Workforce Members on Recognizing and Reporting Security Incidents</title>
    <prop name="label" value="CIS Safeguard 14.6"/>
    <prop name="sort-id" value="cisc-14.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.6_stmt">
-    <p>Train workforce members to be able to recognize a potential incident and be able to report such an incident.</p>
+    <p>Train workforce members to be able to recognize a potential incident and be able to report
+     such an incident.</p>
    </part>
   </control>
   <control id="cisc-14.7">
-   <title>Train Workforce on How to Identify and Report if Their Enterprise Assets are Missing Security Updates</title>
+   <title>Train Workforce on How to Identify and Report if Their Enterprise Assets are Missing
+    Security Updates</title>
    <prop name="label" value="CIS Safeguard 14.7"/>
    <prop name="sort-id" value="cisc-14.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-   name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.7_stmt">
-    <p>Train workforce to understand how to verify and report out-of-date software patches or any failures in automated processes and tools. Part of this training should include notifying IT personnel of any failures in automated processes and tools.</p>
+    <p>Train workforce to understand how to verify and report out-of-date software patches or any
+     failures in automated processes and tools. Part of this training should include notifying IT
+     personnel of any failures in automated processes and tools.</p>
    </part>
   </control>
   <control id="cisc-14.8">
-   <title>Train Workforce on the Dangers of Connecting to and Transmitting Enterprise Data Over Insecure Networks</title>
+   <title>Train Workforce on the Dangers of Connecting to and Transmitting Enterprise Data Over
+    Insecure Networks</title>
    <prop name="label" value="CIS Safeguard 14.8"/>
    <prop name="sort-id" value="cisc-14.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.8_stmt">
-    <p>Train workforce members on the dangers of connecting to, and transmitting data over, insecure networks for enterprise activities. If the enterprise has remote workers, training must include guidance to ensure that all users securely configure their home network infrastructure.</p>
+    <p>Train workforce members on the dangers of connecting to, and transmitting data over, insecure
+     networks for enterprise activities. If the enterprise has remote workers, training must include
+     guidance to ensure that all users securely configure their home network infrastructure.</p>
    </part>
   </control>
   <control id="cisc-14.9">
    <title>Conduct Role-Specific Security Awareness and Skills Training</title>
    <prop name="label" value="CIS Safeguard 14.9"/>
    <prop name="sort-id" value="cisc-14.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-14.9_stmt">
-    <p>Conduct role-specific security awareness and skills training. Example implementations include secure system administration courses for IT professionals, (OWASP® Top 10 vulnerability awareness and prevention training for web application developers, and advanced social engineering awareness training for high-profile roles.</p>
+    <p>Conduct role-specific security awareness and skills training. Example implementations include
+     secure system administration courses for IT professionals, (OWASP® Top 10 vulnerability
+     awareness and prevention training for web application developers, and advanced social
+     engineering awareness training for high-profile roles.</p>
    </part>
-  </control> 
+  </control>
  </control>
  <control id="cisc-15">
   <title>Service Provider Management</title>
   <prop name="label" value="CIS Control 15"/>
   <prop name="sort-id" value="cisc-15"/>
   <part name="statement" id="cisc-15_stmt">
-   <p>Develop a process to evaluate service providers who hold sensitive data, or are responsible for an enterprise’s critical IT platforms or processes, to ensure these providers are protecting those platforms and data appropriately.</p>
+   <p>Develop a process to evaluate service providers who hold sensitive data, or are responsible
+    for an enterprise’s critical IT platforms or processes, to ensure these providers are protecting
+    those platforms and data appropriately.</p>
   </part>
   <part name="guidance" id="cisc-15_gdn">
-   <p>In our modern, connected world, enterprises rely on vendors and partners to help manage their data or rely on third-party infrastructure for core applications or functions.</p>
-   <p>There have been numerous examples where third-party breaches have significantly impacted an enterprise; for example, as early as the late 2000s, payment cards were compromised after attackers infiltrated smaller third-party vendors in the retail industry. More recent examples include ransomware attacks that impact an enterprise indirectly, due to one of their service providers being locked down, causing disruption to business. Or worse, if directly connected, a ransomware attack could encrypt data on the main enterprise.</p>
-   <p>Most data security and privacy regulations require their protection extend to third-party service providers, such as with Health Insurance Portability and Accountability Act (HIPAA) Business Associate agreements in healthcare, Federal Financial Institutions Examination Council (FFIEC) requirements for the financial industry, and the United Kingdom (U.K.) Cyber Essentials. Third-party trust is a core Governance Risk and Compliance (GRC) function, as risks that are not managed within the enterprise are transferred to entities outside the enterprise.</p>
-   <p>While reviewing the security of third-parties has been a task performed for decades, there is not a universal standard for assessing security; and, many service providers are being audited by their customers multiple times a month, causing impacts to their own productivity. This is because every enterprise has a different “checklist” or set of standards to grade the service provider. There are only a few industry standards, such as in finance, with the Shared Assessments program, or in higher education, with their Higher Education Community Vendor Assessment Toolkit (HECVAT). Insurance companies selling cybersecurity policies also have their own measurements.</p>
-   <p>While an enterprise might put a lot of scrutiny into large cloud or application hosting companies because they are hosting their email or critical business applications, smaller firms are often a greater risk. Often times, a third-party service provider contracts with additional parties to provide other plugins or services, such as when a third-party uses a fourth-party platform or product to support the main enterprise.  </p>
+   <p>In our modern, connected world, enterprises rely on vendors and partners to help manage their
+    data or rely on third-party infrastructure for core applications or functions.</p>
+   <p>There have been numerous examples where third-party breaches have significantly impacted an
+    enterprise; for example, as early as the late 2000s, payment cards were compromised after
+    attackers infiltrated smaller third-party vendors in the retail industry. More recent examples
+    include ransomware attacks that impact an enterprise indirectly, due to one of their service
+    providers being locked down, causing disruption to business. Or worse, if directly connected, a
+    ransomware attack could encrypt data on the main enterprise.</p>
+   <p>Most data security and privacy regulations require their protection extend to third-party
+    service providers, such as with Health Insurance Portability and Accountability Act (HIPAA)
+    Business Associate agreements in healthcare, Federal Financial Institutions Examination Council
+    (FFIEC) requirements for the financial industry, and the United Kingdom (U.K.) Cyber Essentials.
+    Third-party trust is a core Governance Risk and Compliance (GRC) function, as risks that are not
+    managed within the enterprise are transferred to entities outside the enterprise.</p>
+   <p>While reviewing the security of third-parties has been a task performed for decades, there is
+    not a universal standard for assessing security; and, many service providers are being audited
+    by their customers multiple times a month, causing impacts to their own productivity. This is
+    because every enterprise has a different “checklist” or set of standards to grade the service
+    provider. There are only a few industry standards, such as in finance, with the Shared
+    Assessments program, or in higher education, with their Higher Education Community Vendor
+    Assessment Toolkit (HECVAT). Insurance companies selling cybersecurity policies also have their
+    own measurements.</p>
+   <p>While an enterprise might put a lot of scrutiny into large cloud or application hosting
+    companies because they are hosting their email or critical business applications, smaller firms
+    are often a greater risk. Often times, a third-party service provider contracts with additional
+    parties to provide other plugins or services, such as when a third-party uses a fourth-party
+    platform or product to support the main enterprise. </p>
   </part>
   <control id="cisc-15.1">
    <title>Establish and Maintain an Inventory of Service Providers</title>
    <prop name="label" value="CIS Safeguard 15.1"/>
    <prop name="sort-id" value="cisc-15.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-15.1_stmt">
-    <p>Establish and maintain an inventory of service providers. The inventory is to list all known service providers, include classification(s), and designate an enterprise contact for each service provider. Review and update the inventory annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain an inventory of service providers. The inventory is to list all known
+     service providers, include classification(s), and designate an enterprise contact for each
+     service provider. Review and update the inventory annually, or when significant enterprise
+     changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-15.2">
    <title>Establish and Maintain a Service Provider Management Policy</title>
    <prop name="label" value="CIS Safeguard 15.2"/>
    <prop name="sort-id" value="cisc-15.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-15.2_stmt">
-    <p>Establish and maintain a service provider management policy. Ensure the policy addresses the classification, inventory, assessment, monitoring, and decommissioning of service providers. Review and update the policy annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a service provider management policy. Ensure the policy addresses the
+     classification, inventory, assessment, monitoring, and decommissioning of service providers.
+     Review and update the policy annually, or when significant enterprise changes occur that could
+     impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-15.3">
    <title>Classify Service Providers</title>
    <prop name="label" value="CIS Safeguard 15.3"/>
    <prop name="sort-id" value="cisc-15.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-15.1"/>
    <link rel="dependency" href="cisc-15.2"/>
    <part name="statement" id="cisc-15.3_stmt">
-    <p>Classify service providers. Classification consideration may include one or more characteristics, such as data sensitivity, data volume, availability requirements, applicable regulations, inherent risk, and mitigated risk. Update and review classifications annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Classify service providers. Classification consideration may include one or more
+     characteristics, such as data sensitivity, data volume, availability requirements, applicable
+     regulations, inherent risk, and mitigated risk. Update and review classifications annually, or
+     when significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-15.4">
    <title>Ensure Service Provider Contracts Include Security Requirements</title>
    <prop name="label" value="CIS Safeguard 15.4"/>
    <prop name="sort-id" value="cisc-15.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-15.1"/>
    <link rel="dependency" href="cisc-15.2"/>
    <part name="statement" id="cisc-15.4_stmt">
-    <p>Ensure service provider contracts include security requirements. Example requirements may include minimum security program requirements, security incident and/or data breach notification and response, data encryption requirements, and data disposal commitments. These security requirements must be consistent with the enterprise’s service provider management policy. Review service provider contracts annually to ensure contracts are not missing security requirements.</p>
+    <p>Ensure service provider contracts include security requirements. Example requirements may
+     include minimum security program requirements, security incident and/or data breach
+     notification and response, data encryption requirements, and data disposal commitments. These
+     security requirements must be consistent with the enterprise’s service provider management
+     policy. Review service provider contracts annually to ensure contracts are not missing security
+     requirements.</p>
    </part>
   </control>
   <control id="cisc-15.5">
    <title>Assess Service Providers</title>
    <prop name="label" value="CIS Safeguard 13.5"/>
    <prop name="sort-id" value="cisc-13.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-15.1"/>
    <link rel="dependency" href="cisc-15.2"/>
    <part name="statement" id="cisc-15.5_stmt">
-    <p>Assess service providers consistent with the enterprise’s service provider management policy. Assessment scope may vary based on classification(s), and may include review of standardized assessment reports, such as Service Organization Control 2 (SOC 2) and Payment Card Industry (PCI) Attestation of Compliance (AoC), customized questionnaires, or other appropriately rigorous processes. Reassess service providers annually, at a minimum, or with new and renewed contracts.</p>
+    <p>Assess service providers consistent with the enterprise’s service provider management policy.
+     Assessment scope may vary based on classification(s), and may include review of standardized
+     assessment reports, such as Service Organization Control 2 (SOC 2) and Payment Card Industry
+     (PCI) Attestation of Compliance (AoC), customized questionnaires, or other appropriately
+     rigorous processes. Reassess service providers annually, at a minimum, or with new and renewed
+     contracts.</p>
    </part>
   </control>
   <control id="cisc-15.6">
    <title>Monitor Service Providers</title>
    <prop name="label" value="CIS Safeguard 15.6"/>
    <prop name="sort-id" value="cisc-15.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="detect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="detect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-15.1"/>
    <link rel="dependency" href="cisc-15.2"/>
    <part name="statement" id="cisc-15.6_stmt">
-    <p>Monitor service providers consistent with the enterprise’s service provider management policy. Monitoring may include periodic reassessment of service provider compliance, monitoring service provider release notes, and dark web monitoring.</p>
+    <p>Monitor service providers consistent with the enterprise’s service provider management
+     policy. Monitoring may include periodic reassessment of service provider compliance, monitoring
+     service provider release notes, and dark web monitoring.</p>
    </part>
   </control>
   <control id="cisc-15.7">
    <title>Securely Decommission Service Providers</title>
    <prop name="label" value="CIS Safeguard 15.7"/>
    <prop name="sort-id" value="cisc-15.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="data"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="data"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-15.1"/>
    <link rel="dependency" href="cisc-15.2"/>
    <part name="statement" id="cisc-15.7_stmt">
-    <p>Securely decommission service providers. Example considerations include user and service account deactivation, termination of data flows, and secure disposal of enterprise data within service provider systems</p>
+    <p>Securely decommission service providers. Example considerations include user and service
+     account deactivation, termination of data flows, and secure disposal of enterprise data within
+     service provider systems</p>
    </part>
   </control>
  </control>
@@ -3038,298 +2472,288 @@
   <prop name="label" value="CIS Control 16"/>
   <prop name="sort-id" value="cisc-16"/>
   <part name="statement" id="cisc-16_stmt">
-   <p>Manage the security life cycle of in-house developed, hosted, or acquired software to prevent, detect, and remediate security weaknesses before they can impact the enterprise.</p>
+   <p>Manage the security life cycle of in-house developed, hosted, or acquired software to prevent,
+    detect, and remediate security weaknesses before they can impact the enterprise.</p>
   </part>
   <part name="guidance" id="cisc-16_gdn">
-   <p>Applications provide a human-friendly interface to allow users to access and manage data in a way that is aligned to business functions. They also minimize the need for users to deal directly with complex (and potentially error-prone) system functions, like logging into a database to insert or modify files. Enterprises use applications to manage their most sensitive data and control access to system resources, and so an attacker can use the application itself to compromise the data, instead of an elaborate network and system hacking sequence, attempting to bypass network security controls and sensors. This is why protecting user credentials (specifically application credentials), defined in CIS Control 6, is so important.Applications provide a human-friendly interface to allow users to access and manage data in a way that is aligned to business functions. They also minimize the need for users to deal directly with complex (and potentially error-prone) system functions, like logging into a database to insert or modify files. Enterprises use applications to manage their most sensitive data and control access to system resources, and so an attacker can use the application itself to compromise the data, instead of an elaborate network and system hacking sequence, attempting to bypass network security controls and sensors. This is why protecting user credentials (specifically application credentials), defined in CIS Control 6, is so important.</p>
-   <p>Lacking credentials, application flaws are the attack vector of choice. However, today’s applications are developed, operated, and maintained in a highly complex, diverse, and dynamic environment. Applications run on multiple platforms; web, mobile, cloud, etc., with application architectures that are more complex than legacy client-server or database-web server structures. Development life cycles have become shorter, transitioning from months or years in long waterfall methodologies, to DevOps cycles with frequent code updates. Also, applications are rarely created from scratch, and are often “assembled” from a complex mix of development frameworks, libraries, existing code, and new code. There are also modern and evolving data protection regulations dealing with user privacy. These may require compliance to regional or sector-specific data protection requirements.</p>
-   <p>These factors make traditional approaches to security, like control (of processes, code sources, run-time environment, etc.), inspection, and testing, much more challenging. Also, the risk that an application vulnerability introduces might not be understood, except in a specific operational setting or context.</p>
-   <p>Application vulnerabilities can be present for many reasons; insecure design, insecure infrastructure, coding mistakes, weak authentication, and failure to test for unusual or unexpected conditions. Attackers can exploit specific vulnerabilities, including buffer overflows, exposure to Structured Query Language (SQL) injection, cross-site scripting, cross-site request forgery, and click-jacking of code to gain access to sensitive data, or take control over vulnerable assets within the infrastructure as a launching point for further attacks.</p>
-   <p>Applications and websites can also be used to harvest credentials, data, or attempt to install malware onto the users who access them.</p>
-   <p>Finally, it is now more common to acquire Software as a Service (SaaS) platforms, where software is developed and managed entirely through a third-party. These might be hosted anywhere in the world. This brings challenges to enterprises who need to know what risks they are accepting with using these platforms; and they often do not have visibility into the development and application security practices of these platforms. Some of these SaaS platforms allow for customizing of their interfaces and databases. Enterprises who extend these applications should follow this CIS Control, similar to if they were doing ground-up customer development.</p>
- </part>
+   <p>Applications provide a human-friendly interface to allow users to access and manage data in a
+    way that is aligned to business functions. They also minimize the need for users to deal
+    directly with complex (and potentially error-prone) system functions, like logging into a
+    database to insert or modify files. Enterprises use applications to manage their most sensitive
+    data and control access to system resources, and so an attacker can use the application itself
+    to compromise the data, instead of an elaborate network and system hacking sequence, attempting
+    to bypass network security controls and sensors. This is why protecting user credentials
+    (specifically application credentials), defined in CIS Control 6, is so important.Applications
+    provide a human-friendly interface to allow users to access and manage data in a way that is
+    aligned to business functions. They also minimize the need for users to deal directly with
+    complex (and potentially error-prone) system functions, like logging into a database to insert
+    or modify files. Enterprises use applications to manage their most sensitive data and control
+    access to system resources, and so an attacker can use the application itself to compromise the
+    data, instead of an elaborate network and system hacking sequence, attempting to bypass network
+    security controls and sensors. This is why protecting user credentials (specifically application
+    credentials), defined in CIS Control 6, is so important.</p>
+   <p>Lacking credentials, application flaws are the attack vector of choice. However, today’s
+    applications are developed, operated, and maintained in a highly complex, diverse, and dynamic
+    environment. Applications run on multiple platforms; web, mobile, cloud, etc., with application
+    architectures that are more complex than legacy client-server or database-web server structures.
+    Development life cycles have become shorter, transitioning from months or years in long
+    waterfall methodologies, to DevOps cycles with frequent code updates. Also, applications are
+    rarely created from scratch, and are often “assembled” from a complex mix of development
+    frameworks, libraries, existing code, and new code. There are also modern and evolving data
+    protection regulations dealing with user privacy. These may require compliance to regional or
+    sector-specific data protection requirements.</p>
+   <p>These factors make traditional approaches to security, like control (of processes, code
+    sources, run-time environment, etc.), inspection, and testing, much more challenging. Also, the
+    risk that an application vulnerability introduces might not be understood, except in a specific
+    operational setting or context.</p>
+   <p>Application vulnerabilities can be present for many reasons; insecure design, insecure
+    infrastructure, coding mistakes, weak authentication, and failure to test for unusual or
+    unexpected conditions. Attackers can exploit specific vulnerabilities, including buffer
+    overflows, exposure to Structured Query Language (SQL) injection, cross-site scripting,
+    cross-site request forgery, and click-jacking of code to gain access to sensitive data, or take
+    control over vulnerable assets within the infrastructure as a launching point for further
+    attacks.</p>
+   <p>Applications and websites can also be used to harvest credentials, data, or attempt to install
+    malware onto the users who access them.</p>
+   <p>Finally, it is now more common to acquire Software as a Service (SaaS) platforms, where
+    software is developed and managed entirely through a third-party. These might be hosted anywhere
+    in the world. This brings challenges to enterprises who need to know what risks they are
+    accepting with using these platforms; and they often do not have visibility into the development
+    and application security practices of these platforms. Some of these SaaS platforms allow for
+    customizing of their interfaces and databases. Enterprises who extend these applications should
+    follow this CIS Control, similar to if they were doing ground-up customer development.</p>
+  </part>
   <control id="cisc-16.1">
    <title>Establish and Maintain a Secure Application Development Process</title>
    <prop name="label" value="CIS Safeguard 16.1"/>
    <prop name="sort-id" value="cisc-16.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-16.1_stmt">
-    <p>Establish and maintain a secure application development process. In the process, address such items as: secure application design standards, secure coding practices, developer training, vulnerability management, security of third-party code, and application security testing procedures. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain a secure application development process. In the process, address such
+     items as: secure application design standards, secure coding practices, developer training,
+     vulnerability management, security of third-party code, and application security testing
+     procedures. Review and update documentation annually, or when significant enterprise changes
+     occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-16.2">
    <title>Establish and Maintain a Process to Accept and Address Software Vulnerabilities</title>
    <prop name="label" value="CIS Safeguard 16.2"/>
    <prop name="sort-id" value="cisc-16.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-16.2_stmt">
-    <p>Establish and maintain a process to accept and address reports of software vulnerabilities, including providing a means for external entities to report. The process is to include such items as: a vulnerability handling policy that identifies reporting process, responsible party for handling vulnerability reports, and a process for intake, assignment, remediation, and remediation testing. As part of the process, use a vulnerability tracking system that includes severity ratings, and metrics for measuring timing for identification, analysis, and remediation of vulnerabilities. Review and update documentation annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
-    <p>Third-party application developers need to consider this an externally-facing policy that helps to set expectations for outside stakeholders.</p>
+    <p>Establish and maintain a process to accept and address reports of software vulnerabilities,
+     including providing a means for external entities to report. The process is to include such
+     items as: a vulnerability handling policy that identifies reporting process, responsible party
+     for handling vulnerability reports, and a process for intake, assignment, remediation, and
+     remediation testing. As part of the process, use a vulnerability tracking system that includes
+     severity ratings, and metrics for measuring timing for identification, analysis, and
+     remediation of vulnerabilities. Review and update documentation annually, or when significant
+     enterprise changes occur that could impact this Safeguard.</p>
+    <p>Third-party application developers need to consider this an externally-facing policy that
+     helps to set expectations for outside stakeholders.</p>
    </part>
   </control>
   <control id="cisc-16.3">
    <title>Perform Root Cause Analysis on Security Vulnerabilities</title>
    <prop name="label" value="CIS Safeguard 16.3"/>
    <prop name="sort-id" value="cisc-16.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-16.2"/>
    <part name="statement" id="cisc-16.3_stmt">
-    <p>Perform root cause analysis on security vulnerabilities. When reviewing vulnerabilities, root cause analysis is the task of evaluating underlying issues that create vulnerabilities in code, and allows development teams to move beyond just fixing individual vulnerabilities as they arise.</p>
+    <p>Perform root cause analysis on security vulnerabilities. When reviewing vulnerabilities, root
+     cause analysis is the task of evaluating underlying issues that create vulnerabilities in code,
+     and allows development teams to move beyond just fixing individual vulnerabilities as they
+     arise.</p>
    </part>
   </control>
   <control id="cisc-16.4">
    <title>Establish and Manage an Inventory of Third-Party Software Components</title>
    <prop name="label" value="CIS Safeguard 16.4"/>
    <prop name="sort-id" value="cisc-16.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-16.4_stmt">
-    <p>Establish and manage an updated inventory of third-party components used in development, often referred to as a “bill of materials,” as well as components slated for future use. This inventory is to include any risks that each third-party component could pose. Evaluate the list at least monthly to identify any changes or updates to these components, and validate that the component is still supported.</p>
+    <p>Establish and manage an updated inventory of third-party components used in development,
+     often referred to as a “bill of materials,” as well as components slated for future use. This
+     inventory is to include any risks that each third-party component could pose. Evaluate the list
+     at least monthly to identify any changes or updates to these components, and validate that the
+     component is still supported.</p>
    </part>
   </control>
   <control id="cisc-16.5">
    <title>Use Up-to-Date and Trusted Third-Party Software Components</title>
    <prop name="label" value="CIS Safeguard 16.5"/>
    <prop name="sort-id" value="cisc-16.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-16.4"/>
    <part name="statement" id="cisc-16.5_stmt">
-    <p>Use up-to-date and trusted third-party software components. When possible, choose established and proven frameworks and libraries that provide adequate security. Acquire these components from trusted sources or evaluate the software for vulnerabilities before use.</p>
+    <p>Use up-to-date and trusted third-party software components. When possible, choose established
+     and proven frameworks and libraries that provide adequate security. Acquire these components
+     from trusted sources or evaluate the software for vulnerabilities before use.</p>
    </part>
   </control>
   <control id="cisc-16.6">
-   <title>Establish and Maintain a Severity Rating System and Process for Application Vulnerabilities</title>
+   <title>Establish and Maintain a Severity Rating System and Process for Application
+    Vulnerabilities</title>
    <prop name="label" value="CIS Safeguard 16.6"/>
    <prop name="sort-id" value="cisc-16.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-16.2"/>
    <part name="statement" id="cisc-16.6_stmt">
-    <p>Establish and maintain a severity rating system and process for application vulnerabilities that facilitates prioritizing the order in which discovered vulnerabilities are fixed. This process includes setting a minimum level of security acceptability for releasing code or applications. Severity ratings bring a systematic way of triaging vulnerabilities that improves risk management and helps ensure the most severe bugs are fixed first. Review and update the system and process annually.</p>
+    <p>Establish and maintain a severity rating system and process for application vulnerabilities
+     that facilitates prioritizing the order in which discovered vulnerabilities are fixed. This
+     process includes setting a minimum level of security acceptability for releasing code or
+     applications. Severity ratings bring a systematic way of triaging vulnerabilities that improves
+     risk management and helps ensure the most severe bugs are fixed first. Review and update the
+     system and process annually.</p>
    </part>
   </control>
   <control id="cisc-16.7">
    <title>Use Standard Hardening Configuration Templates for Application Infrastructure</title>
    <prop name="label" value="CIS Safeguard 16.7"/>
    <prop name="sort-id" value="cisc-16.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-4.1"/>
    <link rel="dependency" href="cisc-4.2"/>
    <part name="statement" id="cisc-16.7_stmt">
-    <p>Use standard, industry-recommended hardening configuration templates for application infrastructure components. This includes underlying servers, databases, and web servers, and applies to cloud containers, Platform as a Service (PaaS) components, and SaaS components. Do not allow in-house developed software to weaken configuration hardening.</p>
+    <p>Use standard, industry-recommended hardening configuration templates for application
+     infrastructure components. This includes underlying servers, databases, and web servers, and
+     applies to cloud containers, Platform as a Service (PaaS) components, and SaaS components. Do
+     not allow in-house developed software to weaken configuration hardening.</p>
    </part>
   </control>
   <control id="cisc-16.8">
    <title>Separate Production and Non-Production Systems</title>
    <prop name="label" value="CIS Safeguard 16.8"/>
    <prop name="sort-id" value="cisc-16.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-16.8_stmt">
-    <p></p>
-    <p>Maintain separate environments for production and non-production systems.</p>  
+    <p/>
+    <p>Maintain separate environments for production and non-production systems.</p>
    </part>
   </control>
   <control id="cisc-16.9">
    <title>Train Developers in Application Security Concepts and Secure Coding</title>
    <prop name="label" value="CIS Safeguard 16.9"/>
    <prop name="sort-id" value="cisc-16.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-16.9_stmt">
-    <p>Ensure that all software development personnel receive training in writing secure code for their specific development environment and responsibilities. Training can include general security principles and application security standard practices. Conduct training at least annually and design in a way to promote security within the development team, and build a culture of security among the developers.</p>
+    <p>Ensure that all software development personnel receive training in writing secure code for
+     their specific development environment and responsibilities. Training can include general
+     security principles and application security standard practices. Conduct training at least
+     annually and design in a way to promote security within the development team, and build a
+     culture of security among the developers.</p>
    </part>
   </control>
   <control id="cisc-16.10">
    <title>Apply Secure Design Principles in Application Architectures</title>
    <prop name="label" value="CIS Safeguard 16.10"/>
    <prop name="sort-id" value="cisc-16.10"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-16.1"/>
    <part name="statement" id="cisc-16.10_stmt">
-    <p>Apply secure design principles in application architectures. Secure design principles include the concept of least privilege and enforcing mediation to validate every operation that the user makes, promoting the concept of “never trust user input.” Examples include ensuring that explicit error checking is performed and documented for all input, including for size, data type, and acceptable ranges or formats. Secure design also means minimizing the application infrastructure attack surface, such as turning off unprotected ports and services, removing unnecessary programs and files, and renaming or removing default accounts.</p>
+    <p>Apply secure design principles in application architectures. Secure design principles include
+     the concept of least privilege and enforcing mediation to validate every operation that the
+     user makes, promoting the concept of “never trust user input.” Examples include ensuring that
+     explicit error checking is performed and documented for all input, including for size, data
+     type, and acceptable ranges or formats. Secure design also means minimizing the application
+     infrastructure attack surface, such as turning off unprotected ports and services, removing
+     unnecessary programs and files, and renaming or removing default accounts.</p>
    </part>
   </control>
   <control id="cisc-16.11">
    <title>Leverage Vetted Modules or Services for Application Security Components</title>
    <prop name="label" value="CIS Safeguard 16.11"/>
    <prop name="sort-id" value="cisc-16.11"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-16.11_stmt">
-    <p>Leverage vetted modules or services for application security components, such as identity management, encryption, and auditing and logging. Using platform features in critical security functions will reduce developers’ workload and minimize the likelihood of design or implementation errors. Modern operating systems provide effective mechanisms for identification, authentication, and authorization and make those mechanisms available to applications. Use only standardized, currently accepted, and extensively reviewed encryption algorithms. Operating systems also provide mechanisms to create and maintain secure audit logs.</p>
+    <p>Leverage vetted modules or services for application security components, such as identity
+     management, encryption, and auditing and logging. Using platform features in critical security
+     functions will reduce developers’ workload and minimize the likelihood of design or
+     implementation errors. Modern operating systems provide effective mechanisms for
+     identification, authentication, and authorization and make those mechanisms available to
+     applications. Use only standardized, currently accepted, and extensively reviewed encryption
+     algorithms. Operating systems also provide mechanisms to create and maintain secure audit
+     logs.</p>
    </part>
   </control>
   <control id="cisc-16.12">
    <title>Implement Code-Level Security Checks</title>
    <prop name="label" value="CIS Safeguard 16.12"/>
    <prop name="sort-id" value="cisc-16.12"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-16.12_stmt">
-    <p>Apply static and dynamic analysis tools within the application life cycle to verify that secure coding practices are being followed.</p>
+    <p>Apply static and dynamic analysis tools within the application life cycle to verify that
+     secure coding practices are being followed.</p>
    </part>
   </control>
   <control id="cisc-16.13">
    <title>Conduct Application Penetration Testing</title>
    <prop name="label" value="CIS Safeguard 16.13"/>
    <prop name="sort-id" value="cisc-16.13"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-16.13_stmt">
-    <p>Conduct application penetration testing. For critical applications, authenticated penetration testing is better suited to finding business logic vulnerabilities than code scanning and automated security testing. Penetration testing relies on the skill of the tester to manually manipulate an application as an authenticated and unauthenticated user.</p>
+    <p>Conduct application penetration testing. For critical applications, authenticated penetration
+     testing is better suited to finding business logic vulnerabilities than code scanning and
+     automated security testing. Penetration testing relies on the skill of the tester to manually
+     manipulate an application as an authenticated and unauthenticated user.</p>
    </part>
   </control>
   <control id="cisc-16.14">
    <title>Conduct Threat Modeling</title>
    <prop name="label" value="CIS Safeguard 16.14"/>
    <prop name="sort-id" value="cisc-16.14"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="applications"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="applications"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-2.1"/>
    <part name="statement" id="cisc-16.14_stmt">
-    <p>Conduct threat modeling. Threat modeling is the process of identifying and addressing application security design flaws within a design, before code is created. It is conducted through specially trained individuals who evaluate the application design and gauge security risks for each entry point and access level. The goal is to map out the application, architecture, and infrastructure in a structured way to understand its weaknesses.</p>
+    <p>Conduct threat modeling. Threat modeling is the process of identifying and addressing
+     application security design flaws within a design, before code is created. It is conducted
+     through specially trained individuals who evaluate the application design and gauge security
+     risks for each entry point and access level. The goal is to map out the application,
+     architecture, and infrastructure in a structured way to understand its weaknesses.</p>
    </part>
   </control>
  </control>
@@ -3338,203 +2762,178 @@
   <prop name="label" value="CIS Control 17"/>
   <prop name="sort-id" value="cisc-17"/>
   <part name="statement" id="cisc-17_stmt">
-   <p>Establish a program to develop and maintain an incident response capability (e.g., policies, plans, procedures, defined roles, training, and communications) to prepare, detect, and quickly respond to an attack.</p>
+   <p>Establish a program to develop and maintain an incident response capability (e.g., policies,
+    plans, procedures, defined roles, training, and communications) to prepare, detect, and quickly
+    respond to an attack.</p>
   </part>
   <part name="guidance" id="cisc-17_gdn">
-   <p>A comprehensive cybersecurity program includes protections, detections, response, and recovery capabilities. Often, the final two get overlooked in immature enterprises, or the response technique to compromised systems is just to re-image them to original state, and move on. The primary goal of incident response is to identify threats on the enterprise, respond to them before they can spread, and remediate them before they can cause harm. Without understanding the full scope of an incident, how it happened, and what can be done to prevent it from happening again, defenders will just be in a perpetual “whack-a-mole” pattern.</p>
-   <p>We cannot expect our protections to be effective 100% of the time. When an incident occurs, if an enterprise does not have a documented plan – even with good people – it is almost impossible to know the right investigative procedures, reporting, data collection, management responsibility, legal protocols, and communications strategy that will allow the enterprise to successfully understand, manage, and recover.</p>
-   <p>Along with detection, containment, and eradication, communication to stakeholders is key. If we are to reduce the probability of material impact due to a cyber event, the enterprise’s leadership must know what potential impact there could be, so that they can help prioritize remediation or restoration decisions that best support the enterprise. These business decisions could be based on regulatory compliance, disclosure rules, service-level agreements with partners or customers, revenue, or mission impacts.</p>
-   <p>Dwell time from when an attack happens to when it is identified can be days, weeks, or months. The longer the attacker is in the enterprise’s infrastructure, the more embedded they become and they will develop more ways to maintain persistent access for when they are eventually discovered. With the rise of ransomware, which is a stable moneymaker for attackers, this dwell time is critical, especially with modern tactics of stealing data before encrypting it for ransom.</p>
+   <p>A comprehensive cybersecurity program includes protections, detections, response, and recovery
+    capabilities. Often, the final two get overlooked in immature enterprises, or the response
+    technique to compromised systems is just to re-image them to original state, and move on. The
+    primary goal of incident response is to identify threats on the enterprise, respond to them
+    before they can spread, and remediate them before they can cause harm. Without understanding the
+    full scope of an incident, how it happened, and what can be done to prevent it from happening
+    again, defenders will just be in a perpetual “whack-a-mole” pattern.</p>
+   <p>We cannot expect our protections to be effective 100% of the time. When an incident occurs, if
+    an enterprise does not have a documented plan – even with good people – it is almost impossible
+    to know the right investigative procedures, reporting, data collection, management
+    responsibility, legal protocols, and communications strategy that will allow the enterprise to
+    successfully understand, manage, and recover.</p>
+   <p>Along with detection, containment, and eradication, communication to stakeholders is key. If
+    we are to reduce the probability of material impact due to a cyber event, the enterprise’s
+    leadership must know what potential impact there could be, so that they can help prioritize
+    remediation or restoration decisions that best support the enterprise. These business decisions
+    could be based on regulatory compliance, disclosure rules, service-level agreements with
+    partners or customers, revenue, or mission impacts.</p>
+   <p>Dwell time from when an attack happens to when it is identified can be days, weeks, or months.
+    The longer the attacker is in the enterprise’s infrastructure, the more embedded they become and
+    they will develop more ways to maintain persistent access for when they are eventually
+    discovered. With the rise of ransomware, which is a stable moneymaker for attackers, this dwell
+    time is critical, especially with modern tactics of stealing data before encrypting it for
+    ransom.</p>
   </part>
   <control id="cisc-17.1">
    <title>Designate Personnel to Manage Incident Handling</title>
    <prop name="label" value="CIS Safeguard 17.1"/>
    <prop name="sort-id" value="cisc-17.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-17.1_stmt">
-    <p>Designate one key person, and at least one backup, who will manage the enterprise’s incident handling process. Management personnel are responsible for the coordination and documentation of incident response and recovery efforts and can consist of employees internal to the enterprise, third-party vendors, or a hybrid approach. If using a third-party vendor, designate at least one person internal to the enterprise to oversee any third-party work. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Designate one key person, and at least one backup, who will manage the enterprise’s incident
+     handling process. Management personnel are responsible for the coordination and documentation
+     of incident response and recovery efforts and can consist of employees internal to the
+     enterprise, third-party vendors, or a hybrid approach. If using a third-party vendor, designate
+     at least one person internal to the enterprise to oversee any third-party work. Review
+     annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-17.2">
    <title>Establish and Maintain Contact Information for Reporting Security Incidents</title>
    <prop name="label" value="CIS Safeguard 17.2"/>
    <prop name="sort-id" value="cisc-17.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-17.2_stmt">
-    <p>Establish and maintain contact information for parties that need to be informed of security incidents. Contacts may include internal staff, third-party vendors, law enforcement, cyber insurance providers, relevant government agencies, Information Sharing and Analysis Center (ISAC) partners, or other stakeholders. Verify contacts annually to ensure that information is up-to-date.</p>
+    <p>Establish and maintain contact information for parties that need to be informed of security
+     incidents. Contacts may include internal staff, third-party vendors, law enforcement, cyber
+     insurance providers, relevant government agencies, Information Sharing and Analysis Center
+     (ISAC) partners, or other stakeholders. Verify contacts annually to ensure that information is
+     up-to-date.</p>
    </part>
   </control>
   <control id="cisc-17.3">
    <title>Establish and Maintain an Enterprise Process for Reporting Incidents</title>
    <prop name="label" value="CIS Safeguard 17.3"/>
    <prop name="sort-id" value="cisc-17.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="1"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="1"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-17.3_stmt">
-    <p>Establish and maintain an enterprise process for the workforce to report security incidents. The process includes reporting timeframe, personnel to report to, mechanism for reporting, and the minimum information to be reported. Ensure the process is publicly available to all of the workforce. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain an enterprise process for the workforce to report security incidents.
+     The process includes reporting timeframe, personnel to report to, mechanism for reporting, and
+     the minimum information to be reported. Ensure the process is publicly available to all of the
+     workforce. Review annually, or when significant enterprise changes occur that could impact this
+     Safeguard.</p>
    </part>
   </control>
   <control id="cisc-17.4">
    <title>Establish and Maintain an Incident Response Process</title>
    <prop name="label" value="CIS Safeguard 17.4"/>
    <prop name="sort-id" value="cisc-17.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-17.4_stmt">
-    <p>Establish and maintain an incident response process that addresses roles and responsibilities, compliance requirements, and a communication plan. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain an incident response process that addresses roles and
+     responsibilities, compliance requirements, and a communication plan. Review annually, or when
+     significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-17.5">
    <title>Assign Key Roles and Responsibilities</title>
    <prop name="label" value="CIS Safeguard 17.5"/>
    <prop name="sort-id" value="cisc-17.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-17.4"/>
    <part name="statement" id="cisc-17.5_stmt">
-    <p>Assign key roles and responsibilities for incident response, including staff from legal, IT, information security, facilities, public relations, human resources, incident responders, and analysts, as applicable. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Assign key roles and responsibilities for incident response, including staff from legal, IT,
+     information security, facilities, public relations, human resources, incident responders, and
+     analysts, as applicable. Review annually, or when significant enterprise changes occur that
+     could impact this Safeguard.</p>
    </part>
   </control>
   <control id="cisc-17.6">
    <title>Define Mechanisms for Communicating During Incident Response</title>
    <prop name="label" value="CIS Safeguard 17.6"/>
    <prop name="sort-id" value="cisc-17.06"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="respond"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="respond"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-17.4"/>
    <part name="statement" id="cisc-17.6_stmt">
-    <p>Determine which primary and secondary mechanisms will be used to communicate and report during a security incident. Mechanisms can include phone calls, emails, or letters. Keep in mind that certain mechanisms, such as emails, can be affected during a security incident. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Determine which primary and secondary mechanisms will be used to communicate and report
+     during a security incident. Mechanisms can include phone calls, emails, or letters. Keep in
+     mind that certain mechanisms, such as emails, can be affected during a security incident.
+     Review annually, or when significant enterprise changes occur that could impact this
+     Safeguard.</p>
    </part>
   </control>
   <control id="cisc-17.7">
    <title>Conduct Routine Incident Response Exercises</title>
    <prop name="label" value="CIS Safeguard 17.7"/>
    <prop name="sort-id" value="cisc-17.07"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recover"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recover"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-17.4"/>
    <part name="statement" id="cisc-17.7_stmt">
-    <p>Plan and conduct routine incident response exercises and scenarios for key personnel involved in the incident response process to prepare for responding to real-world incidents. Exercises need to test communication channels, decision making, and workflows. Conduct testing on an annual basis, at a minimum.</p>
+    <p>Plan and conduct routine incident response exercises and scenarios for key personnel involved
+     in the incident response process to prepare for responding to real-world incidents. Exercises
+     need to test communication channels, decision making, and workflows. Conduct testing on an
+     annual basis, at a minimum.</p>
    </part>
   </control>
   <control id="cisc-17.8">
    <title>Conduct Post-Incident Reviews</title>
    <prop name="label" value="CIS Safeguard 17.8"/>
    <prop name="sort-id" value="cisc-17.08"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="recover"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="recover"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-17.4"/>
    <part name="statement" id="cisc-17.8_stmt">
-    <p>Conduct post-incident reviews. Post-incident reviews help prevent incident recurrence through identifying lessons learned and follow-up action.</p>
+    <p>Conduct post-incident reviews. Post-incident reviews help prevent incident recurrence through
+     identifying lessons learned and follow-up action.</p>
    </part>
   </control>
   <control id="cisc-17.9">
    <title>Establish and Maintain Security Incident Thresholds</title>
    <prop name="label" value="CIS Safeguard 17.9"/>
    <prop name="sort-id" value="cisc-17.09"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-17.4"/>
    <part name="statement" id="cisc-17.9_stmt">
-    <p>Establish and maintain security incident thresholds, including, at a minimum, differentiating between an incident and an event. Examples can include: abnormal activity, security vulnerability, security weakness, data breach, privacy incident, etc. Review annually, or when significant enterprise changes occur that could impact this Safeguard.</p>
+    <p>Establish and maintain security incident thresholds, including, at a minimum, differentiating
+     between an incident and an event. Examples can include: abnormal activity, security
+     vulnerability, security weakness, data breach, privacy incident, etc. Review annually, or when
+     significant enterprise changes occur that could impact this Safeguard.</p>
    </part>
   </control>
  </control>
@@ -3543,111 +2942,115 @@
   <prop name="label" value="CIS Control 18"/>
   <prop name="sort-id" value="cisc-18"/>
   <part name="statement" id="cisc-18_stmt">
-   <p>Test the effectiveness and resiliency of enterprise assets through identifying and exploiting weaknesses in controls (people, processes, and technology), and simulating the objectives and actions of an attacker.</p>
+   <p>Test the effectiveness and resiliency of enterprise assets through identifying and exploiting
+    weaknesses in controls (people, processes, and technology), and simulating the objectives and
+    actions of an attacker.</p>
   </part>
   <part name="guidance" id="cisc-18_gdn">
-   <p>A successful defensive posture requires a comprehensive program of effective policies and governance, strong technical defenses, combined with appropriate action from people. However, it is rarely perfect. In a complex environment where technology is constantly evolving and new attacker tradecraft appears regularly, enterprises should periodically test their controls to identify gaps and to assess their resiliency. This test may be from external network, internal network, application, system, or device perspective. It may include social engineering of users, or physical access control bypasses.</p>
-   <p>Often, penetration tests are performed for specific purposes: • As a “dramatic” demonstration of an attack, usually to convince decision-makers of their enterprise’s weaknesses • As a means to test the correct operation of enterprise defenses (“verification”) • To test that the enterprise has built the right defenses in the first place (“validation”)</p>
-   <p>Independent penetration testing can provide valuable and objective insights about the existence of vulnerabilities in enterprise assets and humans, and the efficacy of defenses and mitigating controls to protect against adverse impacts to the enterprise. They are part of a comprehensive, ongoing program of security management and improvement. They can also reveal process weaknesses, such as incomplete or inconsistent configuration management, or end-user training.</p>
-   <p>Penetration testing differs from vulnerability testing, described in CIS Control 7. Vulnerability testing just checks for presence of known, insecure enterprise assets, and stops there. Penetration testing goes further to exploit those weaknesses to see how far an attacker could get, and what business process or data might be impacted through exploitation of that vulnerability. This is an important detail, and often penetration testing and vulnerability testing are incorrectly used interchangeably. Vulnerability testing is exclusively automated scanning with sometimes manual validation of false positives, whereas penetration testing requires more human involvement and analysis, sometimes supported through the use of custom tools or scripts. However, vulnerability testing is often a starting point for a penetration test.</p>
-   <p>Another common term is “Red Team” exercises. These are similar to penetration tests in that vulnerabilities are exploited; however, the difference is the focus. Red Teams simulate specific attacker TTPs to evaluate how an enterprise’s environment would withstand an attack from a specific adversary, or category of adversaries.</p>
+   <p>A successful defensive posture requires a comprehensive program of effective policies and
+    governance, strong technical defenses, combined with appropriate action from people. However, it
+    is rarely perfect. In a complex environment where technology is constantly evolving and new
+    attacker tradecraft appears regularly, enterprises should periodically test their controls to
+    identify gaps and to assess their resiliency. This test may be from external network, internal
+    network, application, system, or device perspective. It may include social engineering of users,
+    or physical access control bypasses.</p>
+   <p>Often, penetration tests are performed for specific purposes: • As a “dramatic” demonstration
+    of an attack, usually to convince decision-makers of their enterprise’s weaknesses • As a means
+    to test the correct operation of enterprise defenses (“verification”) • To test that the
+    enterprise has built the right defenses in the first place (“validation”)</p>
+   <p>Independent penetration testing can provide valuable and objective insights about the
+    existence of vulnerabilities in enterprise assets and humans, and the efficacy of defenses and
+    mitigating controls to protect against adverse impacts to the enterprise. They are part of a
+    comprehensive, ongoing program of security management and improvement. They can also reveal
+    process weaknesses, such as incomplete or inconsistent configuration management, or end-user
+    training.</p>
+   <p>Penetration testing differs from vulnerability testing, described in CIS Control 7.
+    Vulnerability testing just checks for presence of known, insecure enterprise assets, and stops
+    there. Penetration testing goes further to exploit those weaknesses to see how far an attacker
+    could get, and what business process or data might be impacted through exploitation of that
+    vulnerability. This is an important detail, and often penetration testing and vulnerability
+    testing are incorrectly used interchangeably. Vulnerability testing is exclusively automated
+    scanning with sometimes manual validation of false positives, whereas penetration testing
+    requires more human involvement and analysis, sometimes supported through the use of custom
+    tools or scripts. However, vulnerability testing is often a starting point for a penetration
+    test.</p>
+   <p>Another common term is “Red Team” exercises. These are similar to penetration tests in that
+    vulnerabilities are exploited; however, the difference is the focus. Red Teams simulate specific
+    attacker TTPs to evaluate how an enterprise’s environment would withstand an attack from a
+    specific adversary, or category of adversaries.</p>
   </part>
   <control id="cisc-18.1">
    <title>Establish and Maintain a Penetration Testing Program</title>
    <prop name="label" value="CIS Safeguard 18.1"/>
    <prop name="sort-id" value="cisc-18.01"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <part name="statement" id="cisc-18.1_stmt">
-    <p>Establish and maintain a penetration testing program appropriate to the size, complexity, and maturity of the enterprise. Penetration testing program characteristics include scope, such as network, web application, Application Programming Interface (API), hosted services, and physical premise controls; frequency; limitations, such as acceptable hours, and excluded attack types; point of contact information; remediation, such as how findings will be routed internally; and retrospective requirements.</p>
+    <p>Establish and maintain a penetration testing program appropriate to the size, complexity, and
+     maturity of the enterprise. Penetration testing program characteristics include scope, such as
+     network, web application, Application Programming Interface (API), hosted services, and
+     physical premise controls; frequency; limitations, such as acceptable hours, and excluded
+     attack types; point of contact information; remediation, such as how findings will be routed
+     internally; and retrospective requirements.</p>
    </part>
   </control>
   <control id="cisc-18.2">
    <title>Perform Periodic External Penetration Tests</title>
    <prop name="label" value="CIS Safeguard 18.2"/>
    <prop name="sort-id" value="cisc-18.02"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-18.1"/>
    <part name="statement" id="cisc-18.2_stmt">
-    <p>Perform periodic external penetration tests based on program requirements, no less than annually. External penetration testing must include enterprise and environmental reconnaissance to detect exploitable information. Penetration testing requires specialized skills and experience and must be conducted through a qualified party. The testing may be clear box or opaque box.</p>
+    <p>Perform periodic external penetration tests based on program requirements, no less than
+     annually. External penetration testing must include enterprise and environmental reconnaissance
+     to detect exploitable information. Penetration testing requires specialized skills and
+     experience and must be conducted through a qualified party. The testing may be clear box or
+     opaque box.</p>
    </part>
   </control>
   <control id="cisc-18.3">
    <title>Remediate Penetration Test Findings</title>
    <prop name="label" value="CIS Safeguard 18.3"/>
    <prop name="sort-id" value="cisc-18.03"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/> 
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="2"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="2"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-18.2"/>
    <part name="statement" id="cisc-18.3_stmt">
-    <p>Remediate penetration test findings based on the enterprise’s policy for remediation scope and prioritization.</p>
+    <p>Remediate penetration test findings based on the enterprise’s policy for remediation scope
+     and prioritization.</p>
    </part>
   </control>
   <control id="cisc-18.4">
    <title>Validate Security Measures</title>
    <prop name="label" value="CIS Safeguard 18.4"/>
    <prop name="sort-id" value="cisc-18.04"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="network"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="protect"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="network"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="protect"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-18.1"/>
    <part name="statement" id="cisc-18.4_stmt">
-    <p>Validate security measures after each penetration test. If deemed necessary, modify rulesets and capabilities to detect the techniques used during testing.</p>
+    <p>Validate security measures after each penetration test. If deemed necessary, modify rulesets
+     and capabilities to detect the techniques used during testing.</p>
    </part>
   </control>
   <control id="cisc-18.5">
    <title>Perform Periodic Internal Penetration Tests</title>
    <prop name="label" value="CIS Safeguard 18.5"/>
    <prop name="sort-id" value="cisc-18.05"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="asset-type"
-    value="N/A"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="security-function"
-    value="identify"/>
-   <prop ns="https://cisecurity.org/ns/oscal"
-    name="implementation-group"
-    value="3"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="asset-type" value="N/A"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="security-function" value="identify"/>
+   <prop ns="https://cisecurity.org/ns/oscal" name="implementation-group" value="3"/>
    <link rel="dependency" href="cisc-18.1"/>
    <part name="statement" id="cisc-18.5_stmt">
-    <p>Perform periodic internal penetration tests based on program requirements, no less than annually. The testing may be clear box or opaque box.</p>
+    <p>Perform periodic internal penetration tests based on program requirements, no less than
+     annually. The testing may be clear box or opaque box.</p>
    </part>
   </control>
  </control>


### PR DESCRIPTION
This PR make the following fixes.

- The content is reformatted to make viewing/editing easier.
- Aligning control identifiers in the mapping with the identifiers used in the catalog. The control references now refer to controls in the catalog.
- Corrected the source and target of the mapping.
- Removed the `rlink` from the CCM resource in backmatter to avoid pointing to the wrong resource. Added `TODO` items to reflect work that needs to be done when a public version of the CCM is available in OSCAL format.
